### PR TITLE
fix: set development status classifier to alpha

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -33,10 +33,10 @@ env_vars: {
     value: "docs-staging-v2"
 }
 
-# It will upload the docker image after successful builds.
+# Don't update the docker image from this build
 env_vars: {
     key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "true"
+    value: "false"
 }
 
 # It will always build the docker image.

--- a/.kokoro/docs/docs-presubmit.cfg
+++ b/.kokoro/docs/docs-presubmit.cfg
@@ -10,12 +10,6 @@ env_vars: {
     value: "gcloud-python-test"
 }
 
-# We only upload the image in the main `docs` build.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE_UPLOAD"
-    value: "false"
-}
-
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
     value: "github/python-compute/.kokoro/build.sh"

--- a/.kokoro/docs/docs.cfg
+++ b/.kokoro/docs/docs.cfg
@@ -1,1 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "docs docfx"
+}

--- a/.kokoro/docs/docs.cfg
+++ b/.kokoro/docs/docs.cfg
@@ -1,7 +1,1 @@
 # Format: //devtools/kokoro/config/proto/build.proto
-
-# Only run this nox session.
-env_vars: {
-    key: "NOX_SESSION"
-    value: "docs docfx"
-}

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/compute/",
   "client_documentation": "https://googleapis.dev/python/compute/latest",
   "issue_tracker": "https://issuetracker.google.com/issues/new?component=187134&template=0",
-  "release_level": "beta",
+  "release_level": "alpha",
   "language": "python",
   "repo": "googleapis/python-compute",
   "distribution_name": "google-cloud-compute",

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -18,7 +18,6 @@
 required_envvars+=(
     "STAGING_BUCKET"
     "V2_STAGING_BUCKET"
-    "NOX_SESSION"
 )
 
 # Add env vars which are passed down into the container here.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     ),
     python_requires=">=3.6",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Fix the development status classifier to be consistent with 'alpha' in the README.


Also fixes some docs related kokoro configs. The `docs/docs.cfg` job that is triggered by successfulrelease jobs was failing because `NOX_SESSION` was in the required env vars list.