### PR TITLE
fix: fixing the fetch_gpg_keys.sh script

### DIFF
--- a/.kokoro/docker/docs/Dockerfile
+++ b/.kokoro/docker/docs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ubuntu:20.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/.kokoro/docker/docs/fetch_gpg_keys.sh
+++ b/.kokoro/docker/docs/fetch_gpg_keys.sh
@@ -35,11 +35,11 @@ function retry {
 }
 
 # 3.6.9, 3.7.5 (Ned Deily)
-retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
-      0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+retry 3 gpg --recv-keys 2D347EA6AA65421D
+retry 3 gpg --recv-keys FB9921286F5E1540
 
-# 3.8.0 (Łukasz Langa)
-retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
-      E3FF2839C048B25C084DEBE9B26995E310250568
+# 3.8.0, 3.9.0 (Łukasz Langa)
+retry 3 gpg --recv-keys B26995E310250568
 
-# 
+# 3.10.x and 3.11.x (Pablo Galindo Salgado)
+retry 3 gpg --recv-keys 64E628F8D684696D


### PR DESCRIPTION


Fixes #79 

Updating the fetch_gpg_keys.sh script based on information found on https://www.python.org/downloads/
