### PR TITLE
fix: Kokoro uses separate project for concurent tests.

### DIFF
--- a/samples/snippets/noxfile_config.py
+++ b/samples/snippets/noxfile_config.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TEST_CONFIG_OVERRIDE = {
+    # Tests in test_sample_default_values.py require separate projects to not interfere with each other.
+    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+}


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Making sure that synthtool won't revert the `gcloud_project_env` setting for sample tests like it did in https://github.com/googleapis/python-compute/pull/67
