### PR TITLE
fix: Updated max_results to 100 to avoid too many API calls

### DIFF
--- a/samples/snippets/sample_pagination.py
+++ b/samples/snippets/sample_pagination.py
@@ -34,7 +34,7 @@ def print_images_list(project: str) -> None:
     """
     images_client = compute_v1.ImagesClient()
     # Listing only non-deprecated images to reduce the size of the reply.
-    images_list_request = compute_v1.ListImagesRequest(project=project, max_results=3,
+    images_list_request = compute_v1.ListImagesRequest(project=project, max_results=100,
                                                        filter="deprecated.state != DEPRECATED")
 
     # Although the `max_results` parameter is specified in the request, the iterable returned


### PR DESCRIPTION
Based on @amanda-tarafa comment in C# sample (https://github.com/GoogleCloudPlatform/dotnet-docs-samples/pull/1445/files#r687921807) I am changing the max_results value to 100

Checklist:
- [N/A] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-compute/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [N/A] Appropriate docs were updated (if necessary)

🦕
