### PR TITLE
chore: update to the latest version of the generator

### DIFF
--- a/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
+++ b/google/cloud/compute_v1/services/accelerator_types/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/addresses/client.py
+++ b/google/cloud/compute_v1/services/addresses/client.py
@@ -409,7 +409,7 @@ class AddressesClient(metaclass=AddressesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteAddressRequest, dict] = None,
         *,
@@ -590,7 +590,7 @@ class AddressesClient(metaclass=AddressesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertAddressRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/addresses/transports/rest.py
+++ b/google/cloud/compute_v1/services/addresses/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import AddressesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/autoscalers/client.py
+++ b/google/cloud/compute_v1/services/autoscalers/client.py
@@ -409,7 +409,7 @@ class AutoscalersClient(metaclass=AutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteAutoscalerRequest, dict] = None,
         *,
@@ -592,7 +592,7 @@ class AutoscalersClient(metaclass=AutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertAutoscalerRequest, dict] = None,
         *,
@@ -768,7 +768,7 @@ class AutoscalersClient(metaclass=AutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchAutoscalerRequest, dict] = None,
         *,
@@ -864,7 +864,7 @@ class AutoscalersClient(metaclass=AutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateAutoscalerRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/autoscalers/transports/rest.py
+++ b/google/cloud/compute_v1/services/autoscalers/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import AutoscalersTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/backend_buckets/client.py
+++ b/google/cloud/compute_v1/services/backend_buckets/client.py
@@ -340,7 +340,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_signed_url_key(
+    def add_signed_url_key_unary(
         self,
         request: Union[compute.AddSignedUrlKeyBackendBucketRequest, dict] = None,
         *,
@@ -438,7 +438,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteBackendBucketRequest, dict] = None,
         *,
@@ -525,7 +525,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
         # Done; return the response.
         return response
 
-    def delete_signed_url_key(
+    def delete_signed_url_key_unary(
         self,
         request: Union[compute.DeleteSignedUrlKeyBackendBucketRequest, dict] = None,
         *,
@@ -704,7 +704,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertBackendBucketRequest, dict] = None,
         *,
@@ -864,7 +864,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchBackendBucketRequest, dict] = None,
         *,
@@ -962,7 +962,7 @@ class BackendBucketsClient(metaclass=BackendBucketsClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateBackendBucketRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
+++ b/google/cloud/compute_v1/services/backend_buckets/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/backend_services/client.py
+++ b/google/cloud/compute_v1/services/backend_services/client.py
@@ -340,7 +340,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_signed_url_key(
+    def add_signed_url_key_unary(
         self,
         request: Union[compute.AddSignedUrlKeyBackendServiceRequest, dict] = None,
         *,
@@ -514,7 +514,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteBackendServiceRequest, dict] = None,
         *,
@@ -601,7 +601,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def delete_signed_url_key(
+    def delete_signed_url_key_unary(
         self,
         request: Union[compute.DeleteSignedUrlKeyBackendServiceRequest, dict] = None,
         *,
@@ -875,7 +875,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertBackendServiceRequest, dict] = None,
         *,
@@ -1036,7 +1036,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchBackendServiceRequest, dict] = None,
         *,
@@ -1135,7 +1135,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def set_security_policy(
+    def set_security_policy_unary(
         self,
         request: Union[compute.SetSecurityPolicyBackendServiceRequest, dict] = None,
         *,
@@ -1237,7 +1237,7 @@ class BackendServicesClient(metaclass=BackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateBackendServiceRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/backend_services/transports/rest.py
+++ b/google/cloud/compute_v1/services/backend_services/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/disk_types/transports/rest.py
+++ b/google/cloud/compute_v1/services/disk_types/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import DiskTypesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/disks/client.py
+++ b/google/cloud/compute_v1/services/disks/client.py
@@ -338,7 +338,7 @@ class DisksClient(metaclass=DisksClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_resource_policies(
+    def add_resource_policies_unary(
         self,
         request: Union[compute.AddResourcePoliciesDiskRequest, dict] = None,
         *,
@@ -518,7 +518,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def create_snapshot(
+    def create_snapshot_unary(
         self,
         request: Union[compute.CreateSnapshotDiskRequest, dict] = None,
         *,
@@ -623,7 +623,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteDiskRequest, dict] = None,
         *,
@@ -939,7 +939,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertDiskRequest, dict] = None,
         *,
@@ -1121,7 +1121,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def remove_resource_policies(
+    def remove_resource_policies_unary(
         self,
         request: Union[compute.RemoveResourcePoliciesDiskRequest, dict] = None,
         *,
@@ -1228,7 +1228,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def resize(
+    def resize_unary(
         self,
         request: Union[compute.ResizeDiskRequest, dict] = None,
         *,
@@ -1465,7 +1465,7 @@ class DisksClient(metaclass=DisksClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsDiskRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/disks/transports/rest.py
+++ b/google/cloud/compute_v1/services/disks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import DisksTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/external_vpn_gateways/client.py
+++ b/google/cloud/compute_v1/services/external_vpn_gateways/client.py
@@ -342,7 +342,7 @@ class ExternalVpnGatewaysClient(metaclass=ExternalVpnGatewaysClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteExternalVpnGatewayRequest, dict] = None,
         *,
@@ -517,7 +517,7 @@ class ExternalVpnGatewaysClient(metaclass=ExternalVpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertExternalVpnGatewayRequest, dict] = None,
         *,
@@ -677,7 +677,7 @@ class ExternalVpnGatewaysClient(metaclass=ExternalVpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsExternalVpnGatewayRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
+++ b/google/cloud/compute_v1/services/external_vpn_gateways/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/firewall_policies/client.py
+++ b/google/cloud/compute_v1/services/firewall_policies/client.py
@@ -340,7 +340,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_association(
+    def add_association_unary(
         self,
         request: Union[compute.AddAssociationFirewallPolicyRequest, dict] = None,
         *,
@@ -432,7 +432,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def add_rule(
+    def add_rule_unary(
         self,
         request: Union[compute.AddRuleFirewallPolicyRequest, dict] = None,
         *,
@@ -519,7 +519,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def clone_rules(
+    def clone_rules_unary(
         self,
         request: Union[compute.CloneRulesFirewallPolicyRequest, dict] = None,
         *,
@@ -598,7 +598,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteFirewallPolicyRequest, dict] = None,
         *,
@@ -977,7 +977,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertFirewallPolicyRequest, dict] = None,
         *,
@@ -1164,7 +1164,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def move(
+    def move_unary(
         self,
         request: Union[compute.MoveFirewallPolicyRequest, dict] = None,
         *,
@@ -1253,7 +1253,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchFirewallPolicyRequest, dict] = None,
         *,
@@ -1341,7 +1341,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def patch_rule(
+    def patch_rule_unary(
         self,
         request: Union[compute.PatchRuleFirewallPolicyRequest, dict] = None,
         *,
@@ -1428,7 +1428,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def remove_association(
+    def remove_association_unary(
         self,
         request: Union[compute.RemoveAssociationFirewallPolicyRequest, dict] = None,
         *,
@@ -1508,7 +1508,7 @@ class FirewallPoliciesClient(metaclass=FirewallPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def remove_rule(
+    def remove_rule_unary(
         self,
         request: Union[compute.RemoveRuleFirewallPolicyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
+++ b/google/cloud/compute_v1/services/firewall_policies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/firewalls/client.py
+++ b/google/cloud/compute_v1/services/firewalls/client.py
@@ -338,7 +338,7 @@ class FirewallsClient(metaclass=FirewallsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteFirewallRequest, dict] = None,
         *,
@@ -497,7 +497,7 @@ class FirewallsClient(metaclass=FirewallsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertFirewallRequest, dict] = None,
         *,
@@ -655,7 +655,7 @@ class FirewallsClient(metaclass=FirewallsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchFirewallRequest, dict] = None,
         *,
@@ -750,7 +750,7 @@ class FirewallsClient(metaclass=FirewallsClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateFirewallRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/firewalls/transports/rest.py
+++ b/google/cloud/compute_v1/services/firewalls/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import FirewallsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/forwarding_rules/client.py
+++ b/google/cloud/compute_v1/services/forwarding_rules/client.py
@@ -411,7 +411,7 @@ class ForwardingRulesClient(metaclass=ForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteForwardingRuleRequest, dict] = None,
         *,
@@ -602,7 +602,7 @@ class ForwardingRulesClient(metaclass=ForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertForwardingRuleRequest, dict] = None,
         *,
@@ -783,7 +783,7 @@ class ForwardingRulesClient(metaclass=ForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchForwardingRuleRequest, dict] = None,
         *,
@@ -893,7 +893,7 @@ class ForwardingRulesClient(metaclass=ForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsForwardingRuleRequest, dict] = None,
         *,
@@ -1002,7 +1002,7 @@ class ForwardingRulesClient(metaclass=ForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def set_target(
+    def set_target_unary(
         self,
         request: Union[compute.SetTargetForwardingRuleRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
+++ b/google/cloud/compute_v1/services/forwarding_rules/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_addresses/client.py
+++ b/google/cloud/compute_v1/services/global_addresses/client.py
@@ -340,7 +340,7 @@ class GlobalAddressesClient(metaclass=GlobalAddressesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteGlobalAddressRequest, dict] = None,
         *,
@@ -507,7 +507,7 @@ class GlobalAddressesClient(metaclass=GlobalAddressesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertGlobalAddressRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/global_addresses/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_addresses/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_forwarding_rules/client.py
+++ b/google/cloud/compute_v1/services/global_forwarding_rules/client.py
@@ -342,7 +342,7 @@ class GlobalForwardingRulesClient(metaclass=GlobalForwardingRulesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteGlobalForwardingRuleRequest, dict] = None,
         *,
@@ -515,7 +515,7 @@ class GlobalForwardingRulesClient(metaclass=GlobalForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertGlobalForwardingRuleRequest, dict] = None,
         *,
@@ -676,7 +676,7 @@ class GlobalForwardingRulesClient(metaclass=GlobalForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchGlobalForwardingRuleRequest, dict] = None,
         *,
@@ -774,7 +774,7 @@ class GlobalForwardingRulesClient(metaclass=GlobalForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsGlobalForwardingRuleRequest, dict] = None,
         *,
@@ -875,7 +875,7 @@ class GlobalForwardingRulesClient(metaclass=GlobalForwardingRulesClientMeta):
         # Done; return the response.
         return response
 
-    def set_target(
+    def set_target_unary(
         self,
         request: Union[compute.SetTargetGlobalForwardingRuleRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_forwarding_rules/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
+++ b/google/cloud/compute_v1/services/global_network_endpoint_groups/client.py
@@ -344,7 +344,7 @@ class GlobalNetworkEndpointGroupsClient(
                 always_use_jwt_access=True,
             )
 
-    def attach_network_endpoints(
+    def attach_network_endpoints_unary(
         self,
         request: Union[
             compute.AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest, dict
@@ -459,7 +459,7 @@ class GlobalNetworkEndpointGroupsClient(
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteGlobalNetworkEndpointGroupRequest, dict] = None,
         *,
@@ -549,7 +549,7 @@ class GlobalNetworkEndpointGroupsClient(
         # Done; return the response.
         return response
 
-    def detach_network_endpoints(
+    def detach_network_endpoints_unary(
         self,
         request: Union[
             compute.DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest, dict
@@ -749,7 +749,7 @@ class GlobalNetworkEndpointGroupsClient(
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertGlobalNetworkEndpointGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_network_endpoint_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_operations/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_operations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_organization_operations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
+++ b/google/cloud/compute_v1/services/global_public_delegated_prefixes/client.py
@@ -344,7 +344,7 @@ class GlobalPublicDelegatedPrefixesClient(
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteGlobalPublicDelegatedPrefixeRequest, dict] = None,
         *,
@@ -513,7 +513,7 @@ class GlobalPublicDelegatedPrefixesClient(
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertGlobalPublicDelegatedPrefixeRequest, dict] = None,
         *,
@@ -674,7 +674,7 @@ class GlobalPublicDelegatedPrefixesClient(
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchGlobalPublicDelegatedPrefixeRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
+++ b/google/cloud/compute_v1/services/global_public_delegated_prefixes/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/health_checks/client.py
+++ b/google/cloud/compute_v1/services/health_checks/client.py
@@ -412,7 +412,7 @@ class HealthChecksClient(metaclass=HealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteHealthCheckRequest, dict] = None,
         *,
@@ -592,7 +592,7 @@ class HealthChecksClient(metaclass=HealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertHealthCheckRequest, dict] = None,
         *,
@@ -752,7 +752,7 @@ class HealthChecksClient(metaclass=HealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchHealthCheckRequest, dict] = None,
         *,
@@ -850,7 +850,7 @@ class HealthChecksClient(metaclass=HealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateHealthCheckRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/health_checks/transports/rest.py
+++ b/google/cloud/compute_v1/services/health_checks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import HealthChecksTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/image_family_views/transports/rest.py
+++ b/google/cloud/compute_v1/services/image_family_views/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/images/client.py
+++ b/google/cloud/compute_v1/services/images/client.py
@@ -338,7 +338,7 @@ class ImagesClient(metaclass=ImagesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteImageRequest, dict] = None,
         *,
@@ -422,7 +422,7 @@ class ImagesClient(metaclass=ImagesClientMeta):
         # Done; return the response.
         return response
 
-    def deprecate(
+    def deprecate_unary(
         self,
         request: Union[compute.DeprecateImageRequest, dict] = None,
         *,
@@ -780,7 +780,7 @@ class ImagesClient(metaclass=ImagesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertImageRequest, dict] = None,
         *,
@@ -943,7 +943,7 @@ class ImagesClient(metaclass=ImagesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchImageRequest, dict] = None,
         *,
@@ -1161,7 +1161,7 @@ class ImagesClient(metaclass=ImagesClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsImageRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/images/transports/rest.py
+++ b/google/cloud/compute_v1/services/images/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import ImagesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/instance_group_managers/client.py
+++ b/google/cloud/compute_v1/services/instance_group_managers/client.py
@@ -342,7 +342,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def abandon_instances(
+    def abandon_instances_unary(
         self,
         request: Union[
             compute.AbandonInstancesInstanceGroupManagerRequest, dict
@@ -546,7 +546,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def apply_updates_to_instances(
+    def apply_updates_to_instances_unary(
         self,
         request: Union[
             compute.ApplyUpdatesToInstancesInstanceGroupManagerRequest, dict
@@ -671,7 +671,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def create_instances(
+    def create_instances_unary(
         self,
         request: Union[compute.CreateInstancesInstanceGroupManagerRequest, dict] = None,
         *,
@@ -793,7 +793,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInstanceGroupManagerRequest, dict] = None,
         *,
@@ -893,7 +893,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def delete_instances(
+    def delete_instances_unary(
         self,
         request: Union[compute.DeleteInstancesInstanceGroupManagerRequest, dict] = None,
         *,
@@ -1021,7 +1021,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def delete_per_instance_configs(
+    def delete_per_instance_configs_unary(
         self,
         request: Union[
             compute.DeletePerInstanceConfigsInstanceGroupManagerRequest, dict
@@ -1241,7 +1241,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInstanceGroupManagerRequest, dict] = None,
         *,
@@ -1731,7 +1731,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchInstanceGroupManagerRequest, dict] = None,
         *,
@@ -1853,7 +1853,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def patch_per_instance_configs(
+    def patch_per_instance_configs_unary(
         self,
         request: Union[
             compute.PatchPerInstanceConfigsInstanceGroupManagerRequest, dict
@@ -1982,7 +1982,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def recreate_instances(
+    def recreate_instances_unary(
         self,
         request: Union[
             compute.RecreateInstancesInstanceGroupManagerRequest, dict
@@ -2113,7 +2113,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def resize(
+    def resize_unary(
         self,
         request: Union[compute.ResizeInstanceGroupManagerRequest, dict] = None,
         *,
@@ -2243,7 +2243,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def set_instance_template(
+    def set_instance_template_unary(
         self,
         request: Union[
             compute.SetInstanceTemplateInstanceGroupManagerRequest, dict
@@ -2368,7 +2368,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def set_target_pools(
+    def set_target_pools_unary(
         self,
         request: Union[compute.SetTargetPoolsInstanceGroupManagerRequest, dict] = None,
         *,
@@ -2489,7 +2489,7 @@ class InstanceGroupManagersClient(metaclass=InstanceGroupManagersClientMeta):
         # Done; return the response.
         return response
 
-    def update_per_instance_configs(
+    def update_per_instance_configs_unary(
         self,
         request: Union[
             compute.UpdatePerInstanceConfigsInstanceGroupManagerRequest, dict

--- a/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
+++ b/google/cloud/compute_v1/services/instance_group_managers/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/instance_groups/client.py
+++ b/google/cloud/compute_v1/services/instance_groups/client.py
@@ -340,7 +340,7 @@ class InstanceGroupsClient(metaclass=InstanceGroupsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_instances(
+    def add_instances_unary(
         self,
         request: Union[compute.AddInstancesInstanceGroupRequest, dict] = None,
         *,
@@ -529,7 +529,7 @@ class InstanceGroupsClient(metaclass=InstanceGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInstanceGroupRequest, dict] = None,
         *,
@@ -727,7 +727,7 @@ class InstanceGroupsClient(metaclass=InstanceGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInstanceGroupRequest, dict] = None,
         *,
@@ -1018,7 +1018,7 @@ class InstanceGroupsClient(metaclass=InstanceGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def remove_instances(
+    def remove_instances_unary(
         self,
         request: Union[compute.RemoveInstancesInstanceGroupRequest, dict] = None,
         *,
@@ -1137,7 +1137,7 @@ class InstanceGroupsClient(metaclass=InstanceGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def set_named_ports(
+    def set_named_ports_unary(
         self,
         request: Union[compute.SetNamedPortsInstanceGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/instance_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/instance_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/instance_templates/client.py
+++ b/google/cloud/compute_v1/services/instance_templates/client.py
@@ -342,7 +342,7 @@ class InstanceTemplatesClient(metaclass=InstanceTemplatesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInstanceTemplateRequest, dict] = None,
         *,
@@ -621,7 +621,7 @@ class InstanceTemplatesClient(metaclass=InstanceTemplatesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInstanceTemplateRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/instance_templates/transports/rest.py
+++ b/google/cloud/compute_v1/services/instance_templates/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/instances/client.py
+++ b/google/cloud/compute_v1/services/instances/client.py
@@ -338,7 +338,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_access_config(
+    def add_access_config_unary(
         self,
         request: Union[compute.AddAccessConfigInstanceRequest, dict] = None,
         *,
@@ -454,7 +454,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def add_resource_policies(
+    def add_resource_policies_unary(
         self,
         request: Union[compute.AddResourcePoliciesInstanceRequest, dict] = None,
         *,
@@ -638,7 +638,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def attach_disk(
+    def attach_disk_unary(
         self,
         request: Union[compute.AttachDiskInstanceRequest, dict] = None,
         *,
@@ -745,7 +745,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def bulk_insert(
+    def bulk_insert_unary(
         self,
         request: Union[compute.BulkInsertInstanceRequest, dict] = None,
         *,
@@ -845,7 +845,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInstanceRequest, dict] = None,
         *,
@@ -943,7 +943,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def delete_access_config(
+    def delete_access_config_unary(
         self,
         request: Union[compute.DeleteAccessConfigInstanceRequest, dict] = None,
         *,
@@ -1059,7 +1059,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def detach_disk(
+    def detach_disk_unary(
         self,
         request: Union[compute.DetachDiskInstanceRequest, dict] = None,
         *,
@@ -1799,7 +1799,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInstanceRequest, dict] = None,
         *,
@@ -2077,7 +2077,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def remove_resource_policies(
+    def remove_resource_policies_unary(
         self,
         request: Union[compute.RemoveResourcePoliciesInstanceRequest, dict] = None,
         *,
@@ -2189,7 +2189,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def reset(
+    def reset_unary(
         self,
         request: Union[compute.ResetInstanceRequest, dict] = None,
         *,
@@ -2374,7 +2374,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_deletion_protection(
+    def set_deletion_protection_unary(
         self,
         request: Union[compute.SetDeletionProtectionInstanceRequest, dict] = None,
         *,
@@ -2471,7 +2471,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_disk_auto_delete(
+    def set_disk_auto_delete_unary(
         self,
         request: Union[compute.SetDiskAutoDeleteInstanceRequest, dict] = None,
         *,
@@ -2723,7 +2723,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsInstanceRequest, dict] = None,
         *,
@@ -2833,7 +2833,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_machine_resources(
+    def set_machine_resources_unary(
         self,
         request: Union[compute.SetMachineResourcesInstanceRequest, dict] = None,
         *,
@@ -2943,7 +2943,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_machine_type(
+    def set_machine_type_unary(
         self,
         request: Union[compute.SetMachineTypeInstanceRequest, dict] = None,
         *,
@@ -3053,7 +3053,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_metadata(
+    def set_metadata_unary(
         self,
         request: Union[compute.SetMetadataInstanceRequest, dict] = None,
         *,
@@ -3159,7 +3159,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_min_cpu_platform(
+    def set_min_cpu_platform_unary(
         self,
         request: Union[compute.SetMinCpuPlatformInstanceRequest, dict] = None,
         *,
@@ -3271,7 +3271,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_scheduling(
+    def set_scheduling_unary(
         self,
         request: Union[compute.SetSchedulingInstanceRequest, dict] = None,
         *,
@@ -3377,7 +3377,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_service_account(
+    def set_service_account_unary(
         self,
         request: Union[compute.SetServiceAccountInstanceRequest, dict] = None,
         *,
@@ -3488,7 +3488,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_shielded_instance_integrity_policy(
+    def set_shielded_instance_integrity_policy_unary(
         self,
         request: Union[
             compute.SetShieldedInstanceIntegrityPolicyInstanceRequest, dict
@@ -3606,7 +3606,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def set_tags(
+    def set_tags_unary(
         self,
         request: Union[compute.SetTagsInstanceRequest, dict] = None,
         *,
@@ -3712,7 +3712,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def simulate_maintenance_event(
+    def simulate_maintenance_event_unary(
         self,
         request: Union[compute.SimulateMaintenanceEventInstanceRequest, dict] = None,
         *,
@@ -3811,7 +3811,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def start(
+    def start_unary(
         self,
         request: Union[compute.StartInstanceRequest, dict] = None,
         *,
@@ -3909,7 +3909,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def start_with_encryption_key(
+    def start_with_encryption_key_unary(
         self,
         request: Union[compute.StartWithEncryptionKeyInstanceRequest, dict] = None,
         *,
@@ -4027,7 +4027,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def stop(
+    def stop_unary(
         self,
         request: Union[compute.StopInstanceRequest, dict] = None,
         *,
@@ -4224,7 +4224,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateInstanceRequest, dict] = None,
         *,
@@ -4332,7 +4332,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def update_access_config(
+    def update_access_config_unary(
         self,
         request: Union[compute.UpdateAccessConfigInstanceRequest, dict] = None,
         *,
@@ -4450,7 +4450,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def update_display_device(
+    def update_display_device_unary(
         self,
         request: Union[compute.UpdateDisplayDeviceInstanceRequest, dict] = None,
         *,
@@ -4558,7 +4558,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def update_network_interface(
+    def update_network_interface_unary(
         self,
         request: Union[compute.UpdateNetworkInterfaceInstanceRequest, dict] = None,
         *,
@@ -4679,7 +4679,7 @@ class InstancesClient(metaclass=InstancesClientMeta):
         # Done; return the response.
         return response
 
-    def update_shielded_instance_config(
+    def update_shielded_instance_config_unary(
         self,
         request: Union[
             compute.UpdateShieldedInstanceConfigInstanceRequest, dict

--- a/google/cloud/compute_v1/services/instances/transports/rest.py
+++ b/google/cloud/compute_v1/services/instances/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import InstancesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/interconnect_attachments/client.py
+++ b/google/cloud/compute_v1/services/interconnect_attachments/client.py
@@ -418,7 +418,7 @@ class InterconnectAttachmentsClient(metaclass=InterconnectAttachmentsClientMeta)
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInterconnectAttachmentRequest, dict] = None,
         *,
@@ -601,7 +601,7 @@ class InterconnectAttachmentsClient(metaclass=InterconnectAttachmentsClientMeta)
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInterconnectAttachmentRequest, dict] = None,
         *,
@@ -779,7 +779,7 @@ class InterconnectAttachmentsClient(metaclass=InterconnectAttachmentsClientMeta)
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchInterconnectAttachmentRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
+++ b/google/cloud/compute_v1/services/interconnect_attachments/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
+++ b/google/cloud/compute_v1/services/interconnect_locations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/interconnects/client.py
+++ b/google/cloud/compute_v1/services/interconnects/client.py
@@ -338,7 +338,7 @@ class InterconnectsClient(metaclass=InterconnectsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteInterconnectRequest, dict] = None,
         *,
@@ -575,7 +575,7 @@ class InterconnectsClient(metaclass=InterconnectsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertInterconnectRequest, dict] = None,
         *,
@@ -735,7 +735,7 @@ class InterconnectsClient(metaclass=InterconnectsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchInterconnectRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/interconnects/transports/rest.py
+++ b/google/cloud/compute_v1/services/interconnects/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/license_codes/transports/rest.py
+++ b/google/cloud/compute_v1/services/license_codes/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import LicenseCodesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/licenses/client.py
+++ b/google/cloud/compute_v1/services/licenses/client.py
@@ -338,7 +338,7 @@ class LicensesClient(metaclass=LicensesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteLicenseRequest, dict] = None,
         *,
@@ -618,7 +618,7 @@ class LicensesClient(metaclass=LicensesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertLicenseRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/licenses/transports/rest.py
+++ b/google/cloud/compute_v1/services/licenses/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import LicensesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/machine_types/transports/rest.py
+++ b/google/cloud/compute_v1/services/machine_types/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import MachineTypesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/network_endpoint_groups/client.py
+++ b/google/cloud/compute_v1/services/network_endpoint_groups/client.py
@@ -414,7 +414,7 @@ class NetworkEndpointGroupsClient(metaclass=NetworkEndpointGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def attach_network_endpoints(
+    def attach_network_endpoints_unary(
         self,
         request: Union[
             compute.AttachNetworkEndpointsNetworkEndpointGroupRequest, dict
@@ -536,7 +536,7 @@ class NetworkEndpointGroupsClient(metaclass=NetworkEndpointGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteNetworkEndpointGroupRequest, dict] = None,
         *,
@@ -639,7 +639,7 @@ class NetworkEndpointGroupsClient(metaclass=NetworkEndpointGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def detach_network_endpoints(
+    def detach_network_endpoints_unary(
         self,
         request: Union[
             compute.DetachNetworkEndpointsNetworkEndpointGroupRequest, dict
@@ -857,7 +857,7 @@ class NetworkEndpointGroupsClient(metaclass=NetworkEndpointGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertNetworkEndpointGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/network_endpoint_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/networks/client.py
+++ b/google/cloud/compute_v1/services/networks/client.py
@@ -338,7 +338,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_peering(
+    def add_peering_unary(
         self,
         request: Union[compute.AddPeeringNetworkRequest, dict] = None,
         *,
@@ -437,7 +437,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteNetworkRequest, dict] = None,
         *,
@@ -666,7 +666,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertNetworkRequest, dict] = None,
         *,
@@ -903,7 +903,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchNetworkRequest, dict] = None,
         *,
@@ -997,7 +997,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def remove_peering(
+    def remove_peering_unary(
         self,
         request: Union[compute.RemovePeeringNetworkRequest, dict] = None,
         *,
@@ -1096,7 +1096,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def switch_to_custom_mode(
+    def switch_to_custom_mode_unary(
         self,
         request: Union[compute.SwitchToCustomModeNetworkRequest, dict] = None,
         *,
@@ -1182,7 +1182,7 @@ class NetworksClient(metaclass=NetworksClientMeta):
         # Done; return the response.
         return response
 
-    def update_peering(
+    def update_peering_unary(
         self,
         request: Union[compute.UpdatePeeringNetworkRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/networks/transports/rest.py
+++ b/google/cloud/compute_v1/services/networks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import NetworksTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/node_groups/client.py
+++ b/google/cloud/compute_v1/services/node_groups/client.py
@@ -338,7 +338,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_nodes(
+    def add_nodes_unary(
         self,
         request: Union[compute.AddNodesNodeGroupRequest, dict] = None,
         *,
@@ -518,7 +518,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteNodeGroupRequest, dict] = None,
         *,
@@ -615,7 +615,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def delete_nodes(
+    def delete_nodes_unary(
         self,
         request: Union[compute.DeleteNodesNodeGroupRequest, dict] = None,
         *,
@@ -939,7 +939,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertNodeGroupRequest, dict] = None,
         *,
@@ -1221,7 +1221,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchNodeGroupRequest, dict] = None,
         *,
@@ -1460,7 +1460,7 @@ class NodeGroupsClient(metaclass=NodeGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def set_node_template(
+    def set_node_template_unary(
         self,
         request: Union[compute.SetNodeTemplateNodeGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/node_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/node_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import NodeGroupsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/node_templates/client.py
+++ b/google/cloud/compute_v1/services/node_templates/client.py
@@ -409,7 +409,7 @@ class NodeTemplatesClient(metaclass=NodeTemplatesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteNodeTemplateRequest, dict] = None,
         *,
@@ -714,7 +714,7 @@ class NodeTemplatesClient(metaclass=NodeTemplatesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertNodeTemplateRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/node_templates/transports/rest.py
+++ b/google/cloud/compute_v1/services/node_templates/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/node_types/transports/rest.py
+++ b/google/cloud/compute_v1/services/node_types/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import NodeTypesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/packet_mirrorings/client.py
+++ b/google/cloud/compute_v1/services/packet_mirrorings/client.py
@@ -412,7 +412,7 @@ class PacketMirroringsClient(metaclass=PacketMirroringsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeletePacketMirroringRequest, dict] = None,
         *,
@@ -597,7 +597,7 @@ class PacketMirroringsClient(metaclass=PacketMirroringsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertPacketMirroringRequest, dict] = None,
         *,
@@ -774,7 +774,7 @@ class PacketMirroringsClient(metaclass=PacketMirroringsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchPacketMirroringRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
+++ b/google/cloud/compute_v1/services/packet_mirrorings/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/projects/client.py
+++ b/google/cloud/compute_v1/services/projects/client.py
@@ -338,7 +338,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def disable_xpn_host(
+    def disable_xpn_host_unary(
         self,
         request: Union[compute.DisableXpnHostProjectRequest, dict] = None,
         *,
@@ -415,7 +415,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def disable_xpn_resource(
+    def disable_xpn_resource_unary(
         self,
         request: Union[compute.DisableXpnResourceProjectRequest, dict] = None,
         *,
@@ -505,7 +505,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def enable_xpn_host(
+    def enable_xpn_host_unary(
         self,
         request: Union[compute.EnableXpnHostProjectRequest, dict] = None,
         *,
@@ -582,7 +582,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def enable_xpn_resource(
+    def enable_xpn_resource_unary(
         self,
         request: Union[compute.EnableXpnResourceProjectRequest, dict] = None,
         *,
@@ -961,7 +961,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def move_disk(
+    def move_disk_unary(
         self,
         request: Union[compute.MoveDiskProjectRequest, dict] = None,
         *,
@@ -1046,7 +1046,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def move_instance(
+    def move_instance_unary(
         self,
         request: Union[compute.MoveInstanceProjectRequest, dict] = None,
         *,
@@ -1132,7 +1132,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def set_common_instance_metadata(
+    def set_common_instance_metadata_unary(
         self,
         request: Union[compute.SetCommonInstanceMetadataProjectRequest, dict] = None,
         *,
@@ -1221,7 +1221,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def set_default_network_tier(
+    def set_default_network_tier_unary(
         self,
         request: Union[compute.SetDefaultNetworkTierProjectRequest, dict] = None,
         *,
@@ -1313,7 +1313,7 @@ class ProjectsClient(metaclass=ProjectsClientMeta):
         # Done; return the response.
         return response
 
-    def set_usage_export_bucket(
+    def set_usage_export_bucket_unary(
         self,
         request: Union[compute.SetUsageExportBucketProjectRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/projects/transports/rest.py
+++ b/google/cloud/compute_v1/services/projects/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import ProjectsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
+++ b/google/cloud/compute_v1/services/public_advertised_prefixes/client.py
@@ -342,7 +342,7 @@ class PublicAdvertisedPrefixesClient(metaclass=PublicAdvertisedPrefixesClientMet
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeletePublicAdvertisedPrefixeRequest, dict] = None,
         *,
@@ -508,7 +508,7 @@ class PublicAdvertisedPrefixesClient(metaclass=PublicAdvertisedPrefixesClientMet
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertPublicAdvertisedPrefixeRequest, dict] = None,
         *,
@@ -668,7 +668,7 @@ class PublicAdvertisedPrefixesClient(metaclass=PublicAdvertisedPrefixesClientMet
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchPublicAdvertisedPrefixeRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
+++ b/google/cloud/compute_v1/services/public_advertised_prefixes/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
+++ b/google/cloud/compute_v1/services/public_delegated_prefixes/client.py
@@ -420,7 +420,7 @@ class PublicDelegatedPrefixesClient(metaclass=PublicDelegatedPrefixesClientMeta)
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeletePublicDelegatedPrefixeRequest, dict] = None,
         *,
@@ -606,7 +606,7 @@ class PublicDelegatedPrefixesClient(metaclass=PublicDelegatedPrefixesClientMeta)
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertPublicDelegatedPrefixeRequest, dict] = None,
         *,
@@ -783,7 +783,7 @@ class PublicDelegatedPrefixesClient(metaclass=PublicDelegatedPrefixesClientMeta)
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchPublicDelegatedPrefixeRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
+++ b/google/cloud/compute_v1/services/public_delegated_prefixes/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_autoscalers/client.py
+++ b/google/cloud/compute_v1/services/region_autoscalers/client.py
@@ -342,7 +342,7 @@ class RegionAutoscalersClient(metaclass=RegionAutoscalersClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionAutoscalerRequest, dict] = None,
         *,
@@ -528,7 +528,7 @@ class RegionAutoscalersClient(metaclass=RegionAutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionAutoscalerRequest, dict] = None,
         *,
@@ -707,7 +707,7 @@ class RegionAutoscalersClient(metaclass=RegionAutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionAutoscalerRequest, dict] = None,
         *,
@@ -805,7 +805,7 @@ class RegionAutoscalersClient(metaclass=RegionAutoscalersClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateRegionAutoscalerRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_autoscalers/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_backend_services/client.py
+++ b/google/cloud/compute_v1/services/region_backend_services/client.py
@@ -342,7 +342,7 @@ class RegionBackendServicesClient(metaclass=RegionBackendServicesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionBackendServiceRequest, dict] = None,
         *,
@@ -633,7 +633,7 @@ class RegionBackendServicesClient(metaclass=RegionBackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionBackendServiceRequest, dict] = None,
         *,
@@ -816,7 +816,7 @@ class RegionBackendServicesClient(metaclass=RegionBackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionBackendServiceRequest, dict] = None,
         *,
@@ -927,7 +927,7 @@ class RegionBackendServicesClient(metaclass=RegionBackendServicesClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateRegionBackendServiceRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_backend_services/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_commitments/client.py
+++ b/google/cloud/compute_v1/services/region_commitments/client.py
@@ -503,7 +503,7 @@ class RegionCommitmentsClient(metaclass=RegionCommitmentsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionCommitmentRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_commitments/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_commitments/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_disk_types/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_disks/client.py
+++ b/google/cloud/compute_v1/services/region_disks/client.py
@@ -338,7 +338,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_resource_policies(
+    def add_resource_policies_unary(
         self,
         request: Union[compute.AddResourcePoliciesRegionDiskRequest, dict] = None,
         *,
@@ -447,7 +447,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def create_snapshot(
+    def create_snapshot_unary(
         self,
         request: Union[compute.CreateSnapshotRegionDiskRequest, dict] = None,
         *,
@@ -550,7 +550,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionDiskRequest, dict] = None,
         *,
@@ -862,7 +862,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionDiskRequest, dict] = None,
         *,
@@ -1037,7 +1037,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def remove_resource_policies(
+    def remove_resource_policies_unary(
         self,
         request: Union[compute.RemoveResourcePoliciesRegionDiskRequest, dict] = None,
         *,
@@ -1149,7 +1149,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def resize(
+    def resize_unary(
         self,
         request: Union[compute.ResizeRegionDiskRequest, dict] = None,
         *,
@@ -1388,7 +1388,7 @@ class RegionDisksClient(metaclass=RegionDisksClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsRegionDiskRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_disks/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_disks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import RegionDisksTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/region_health_check_services/client.py
+++ b/google/cloud/compute_v1/services/region_health_check_services/client.py
@@ -342,7 +342,7 @@ class RegionHealthCheckServicesClient(metaclass=RegionHealthCheckServicesClientM
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionHealthCheckServiceRequest, dict] = None,
         *,
@@ -526,7 +526,7 @@ class RegionHealthCheckServicesClient(metaclass=RegionHealthCheckServicesClientM
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionHealthCheckServiceRequest, dict] = None,
         *,
@@ -706,7 +706,7 @@ class RegionHealthCheckServicesClient(metaclass=RegionHealthCheckServicesClientM
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionHealthCheckServiceRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_health_check_services/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_health_checks/client.py
+++ b/google/cloud/compute_v1/services/region_health_checks/client.py
@@ -342,7 +342,7 @@ class RegionHealthChecksClient(metaclass=RegionHealthChecksClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionHealthCheckRequest, dict] = None,
         *,
@@ -542,7 +542,7 @@ class RegionHealthChecksClient(metaclass=RegionHealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionHealthCheckRequest, dict] = None,
         *,
@@ -722,7 +722,7 @@ class RegionHealthChecksClient(metaclass=RegionHealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionHealthCheckRequest, dict] = None,
         *,
@@ -832,7 +832,7 @@ class RegionHealthChecksClient(metaclass=RegionHealthChecksClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateRegionHealthCheckRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_health_checks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_instance_group_managers/client.py
+++ b/google/cloud/compute_v1/services/region_instance_group_managers/client.py
@@ -344,7 +344,7 @@ class RegionInstanceGroupManagersClient(
                 always_use_jwt_access=True,
             )
 
-    def abandon_instances(
+    def abandon_instances_unary(
         self,
         request: Union[
             compute.AbandonInstancesRegionInstanceGroupManagerRequest, dict
@@ -478,7 +478,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def apply_updates_to_instances(
+    def apply_updates_to_instances_unary(
         self,
         request: Union[
             compute.ApplyUpdatesToInstancesRegionInstanceGroupManagerRequest, dict
@@ -604,7 +604,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def create_instances(
+    def create_instances_unary(
         self,
         request: Union[
             compute.CreateInstancesRegionInstanceGroupManagerRequest, dict
@@ -733,7 +733,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionInstanceGroupManagerRequest, dict] = None,
         *,
@@ -831,7 +831,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def delete_instances(
+    def delete_instances_unary(
         self,
         request: Union[
             compute.DeleteInstancesRegionInstanceGroupManagerRequest, dict
@@ -964,7 +964,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def delete_per_instance_configs(
+    def delete_per_instance_configs_unary(
         self,
         request: Union[
             compute.DeletePerInstanceConfigsRegionInstanceGroupManagerRequest, dict
@@ -1182,7 +1182,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionInstanceGroupManagerRequest, dict] = None,
         *,
@@ -1673,7 +1673,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionInstanceGroupManagerRequest, dict] = None,
         *,
@@ -1795,7 +1795,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def patch_per_instance_configs(
+    def patch_per_instance_configs_unary(
         self,
         request: Union[
             compute.PatchPerInstanceConfigsRegionInstanceGroupManagerRequest, dict
@@ -1923,7 +1923,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def recreate_instances(
+    def recreate_instances_unary(
         self,
         request: Union[
             compute.RecreateInstancesRegionInstanceGroupManagerRequest, dict
@@ -2054,7 +2054,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def resize(
+    def resize_unary(
         self,
         request: Union[compute.ResizeRegionInstanceGroupManagerRequest, dict] = None,
         *,
@@ -2171,7 +2171,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def set_instance_template(
+    def set_instance_template_unary(
         self,
         request: Union[
             compute.SetInstanceTemplateRegionInstanceGroupManagerRequest, dict
@@ -2293,7 +2293,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def set_target_pools(
+    def set_target_pools_unary(
         self,
         request: Union[
             compute.SetTargetPoolsRegionInstanceGroupManagerRequest, dict
@@ -2414,7 +2414,7 @@ class RegionInstanceGroupManagersClient(
         # Done; return the response.
         return response
 
-    def update_per_instance_configs(
+    def update_per_instance_configs_unary(
         self,
         request: Union[
             compute.UpdatePerInstanceConfigsRegionInstanceGroupManagerRequest, dict

--- a/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_instance_group_managers/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_instance_groups/client.py
+++ b/google/cloud/compute_v1/services/region_instance_groups/client.py
@@ -634,7 +634,7 @@ class RegionInstanceGroupsClient(metaclass=RegionInstanceGroupsClientMeta):
         # Done; return the response.
         return response
 
-    def set_named_ports(
+    def set_named_ports_unary(
         self,
         request: Union[compute.SetNamedPortsRegionInstanceGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_instance_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_instances/client.py
+++ b/google/cloud/compute_v1/services/region_instances/client.py
@@ -339,7 +339,7 @@ class RegionInstancesClient(metaclass=RegionInstancesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def bulk_insert(
+    def bulk_insert_unary(
         self,
         request: Union[compute.BulkInsertRegionInstanceRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_instances/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_instances/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
+++ b/google/cloud/compute_v1/services/region_network_endpoint_groups/client.py
@@ -344,7 +344,7 @@ class RegionNetworkEndpointGroupsClient(
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionNetworkEndpointGroupRequest, dict] = None,
         *,
@@ -541,7 +541,7 @@ class RegionNetworkEndpointGroupsClient(
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionNetworkEndpointGroupRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_network_endpoint_groups/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_notification_endpoints/client.py
+++ b/google/cloud/compute_v1/services/region_notification_endpoints/client.py
@@ -344,7 +344,7 @@ class RegionNotificationEndpointsClient(
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionNotificationEndpointRequest, dict] = None,
         *,
@@ -532,7 +532,7 @@ class RegionNotificationEndpointsClient(
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionNotificationEndpointRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_notification_endpoints/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_operations/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_operations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_ssl_certificates/client.py
+++ b/google/cloud/compute_v1/services/region_ssl_certificates/client.py
@@ -342,7 +342,7 @@ class RegionSslCertificatesClient(metaclass=RegionSslCertificatesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionSslCertificateRequest, dict] = None,
         *,
@@ -540,7 +540,7 @@ class RegionSslCertificatesClient(metaclass=RegionSslCertificatesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionSslCertificateRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_ssl_certificates/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_target_http_proxies/client.py
+++ b/google/cloud/compute_v1/services/region_target_http_proxies/client.py
@@ -342,7 +342,7 @@ class RegionTargetHttpProxiesClient(metaclass=RegionTargetHttpProxiesClientMeta)
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionTargetHttpProxyRequest, dict] = None,
         *,
@@ -536,7 +536,7 @@ class RegionTargetHttpProxiesClient(metaclass=RegionTargetHttpProxiesClientMeta)
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionTargetHttpProxyRequest, dict] = None,
         *,
@@ -717,7 +717,7 @@ class RegionTargetHttpProxiesClient(metaclass=RegionTargetHttpProxiesClientMeta)
         # Done; return the response.
         return response
 
-    def set_url_map(
+    def set_url_map_unary(
         self,
         request: Union[compute.SetUrlMapRegionTargetHttpProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_target_http_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_target_https_proxies/client.py
+++ b/google/cloud/compute_v1/services/region_target_https_proxies/client.py
@@ -342,7 +342,7 @@ class RegionTargetHttpsProxiesClient(metaclass=RegionTargetHttpsProxiesClientMet
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionTargetHttpsProxyRequest, dict] = None,
         *,
@@ -535,7 +535,7 @@ class RegionTargetHttpsProxiesClient(metaclass=RegionTargetHttpsProxiesClientMet
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionTargetHttpsProxyRequest, dict] = None,
         *,
@@ -717,7 +717,7 @@ class RegionTargetHttpsProxiesClient(metaclass=RegionTargetHttpsProxiesClientMet
         # Done; return the response.
         return response
 
-    def set_ssl_certificates(
+    def set_ssl_certificates_unary(
         self,
         request: Union[
             compute.SetSslCertificatesRegionTargetHttpsProxyRequest, dict
@@ -838,7 +838,7 @@ class RegionTargetHttpsProxiesClient(metaclass=RegionTargetHttpsProxiesClientMet
         # Done; return the response.
         return response
 
-    def set_url_map(
+    def set_url_map_unary(
         self,
         request: Union[compute.SetUrlMapRegionTargetHttpsProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_target_https_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/region_url_maps/client.py
+++ b/google/cloud/compute_v1/services/region_url_maps/client.py
@@ -338,7 +338,7 @@ class RegionUrlMapsClient(metaclass=RegionUrlMapsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRegionUrlMapRequest, dict] = None,
         *,
@@ -539,7 +539,7 @@ class RegionUrlMapsClient(metaclass=RegionUrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRegionUrlMapRequest, dict] = None,
         *,
@@ -718,7 +718,7 @@ class RegionUrlMapsClient(metaclass=RegionUrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRegionUrlMapRequest, dict] = None,
         *,
@@ -824,7 +824,7 @@ class RegionUrlMapsClient(metaclass=RegionUrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateRegionUrlMapRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
+++ b/google/cloud/compute_v1/services/region_url_maps/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/regions/transports/rest.py
+++ b/google/cloud/compute_v1/services/regions/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import RegionsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/reservations/client.py
+++ b/google/cloud/compute_v1/services/reservations/client.py
@@ -410,7 +410,7 @@ class ReservationsClient(metaclass=ReservationsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteReservationRequest, dict] = None,
         *,
@@ -710,7 +710,7 @@ class ReservationsClient(metaclass=ReservationsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertReservationRequest, dict] = None,
         *,
@@ -884,7 +884,7 @@ class ReservationsClient(metaclass=ReservationsClientMeta):
         # Done; return the response.
         return response
 
-    def resize(
+    def resize_unary(
         self,
         request: Union[compute.ResizeReservationRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/reservations/transports/rest.py
+++ b/google/cloud/compute_v1/services/reservations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import ReservationsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/resource_policies/client.py
+++ b/google/cloud/compute_v1/services/resource_policies/client.py
@@ -412,7 +412,7 @@ class ResourcePoliciesClient(metaclass=ResourcePoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteResourcePolicyRequest, dict] = None,
         *,
@@ -716,7 +716,7 @@ class ResourcePoliciesClient(metaclass=ResourcePoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertResourcePolicyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/resource_policies/transports/rest.py
+++ b/google/cloud/compute_v1/services/resource_policies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/routers/client.py
+++ b/google/cloud/compute_v1/services/routers/client.py
@@ -410,7 +410,7 @@ class RoutersClient(metaclass=RoutersClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRouterRequest, dict] = None,
         *,
@@ -759,7 +759,7 @@ class RoutersClient(metaclass=RoutersClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRouterRequest, dict] = None,
         *,
@@ -932,7 +932,7 @@ class RoutersClient(metaclass=RoutersClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchRouterRequest, dict] = None,
         *,
@@ -1122,7 +1122,7 @@ class RoutersClient(metaclass=RoutersClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateRouterRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/routers/transports/rest.py
+++ b/google/cloud/compute_v1/services/routers/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import RoutersTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/routes/client.py
+++ b/google/cloud/compute_v1/services/routes/client.py
@@ -338,7 +338,7 @@ class RoutesClient(metaclass=RoutesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteRouteRequest, dict] = None,
         *,
@@ -498,7 +498,7 @@ class RoutesClient(metaclass=RoutesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertRouteRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/routes/transports/rest.py
+++ b/google/cloud/compute_v1/services/routes/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import RoutesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/security_policies/client.py
+++ b/google/cloud/compute_v1/services/security_policies/client.py
@@ -340,7 +340,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_rule(
+    def add_rule_unary(
         self,
         request: Union[compute.AddRuleSecurityPolicyRequest, dict] = None,
         *,
@@ -437,7 +437,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteSecurityPolicyRequest, dict] = None,
         *,
@@ -677,7 +677,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertSecurityPolicyRequest, dict] = None,
         *,
@@ -906,7 +906,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchSecurityPolicyRequest, dict] = None,
         *,
@@ -1004,7 +1004,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def patch_rule(
+    def patch_rule_unary(
         self,
         request: Union[compute.PatchRuleSecurityPolicyRequest, dict] = None,
         *,
@@ -1101,7 +1101,7 @@ class SecurityPoliciesClient(metaclass=SecurityPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def remove_rule(
+    def remove_rule_unary(
         self,
         request: Union[compute.RemoveRuleSecurityPolicyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/security_policies/transports/rest.py
+++ b/google/cloud/compute_v1/services/security_policies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/service_attachments/client.py
+++ b/google/cloud/compute_v1/services/service_attachments/client.py
@@ -419,7 +419,7 @@ class ServiceAttachmentsClient(metaclass=ServiceAttachmentsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteServiceAttachmentRequest, dict] = None,
         *,
@@ -727,7 +727,7 @@ class ServiceAttachmentsClient(metaclass=ServiceAttachmentsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertServiceAttachmentRequest, dict] = None,
         *,
@@ -902,7 +902,7 @@ class ServiceAttachmentsClient(metaclass=ServiceAttachmentsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchServiceAttachmentRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/service_attachments/transports/rest.py
+++ b/google/cloud/compute_v1/services/service_attachments/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/snapshots/client.py
+++ b/google/cloud/compute_v1/services/snapshots/client.py
@@ -338,7 +338,7 @@ class SnapshotsClient(metaclass=SnapshotsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteSnapshotRequest, dict] = None,
         *,
@@ -817,7 +817,7 @@ class SnapshotsClient(metaclass=SnapshotsClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsSnapshotRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/snapshots/transports/rest.py
+++ b/google/cloud/compute_v1/services/snapshots/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import SnapshotsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/ssl_certificates/client.py
+++ b/google/cloud/compute_v1/services/ssl_certificates/client.py
@@ -414,7 +414,7 @@ class SslCertificatesClient(metaclass=SslCertificatesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteSslCertificateRequest, dict] = None,
         *,
@@ -591,7 +591,7 @@ class SslCertificatesClient(metaclass=SslCertificatesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertSslCertificateRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
+++ b/google/cloud/compute_v1/services/ssl_certificates/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/ssl_policies/client.py
+++ b/google/cloud/compute_v1/services/ssl_policies/client.py
@@ -338,7 +338,7 @@ class SslPoliciesClient(metaclass=SslPoliciesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteSslPolicyRequest, dict] = None,
         *,
@@ -507,7 +507,7 @@ class SslPoliciesClient(metaclass=SslPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertSslPolicyRequest, dict] = None,
         *,
@@ -729,7 +729,7 @@ class SslPoliciesClient(metaclass=SslPoliciesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchSslPolicyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
+++ b/google/cloud/compute_v1/services/ssl_policies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import SslPoliciesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/subnetworks/client.py
+++ b/google/cloud/compute_v1/services/subnetworks/client.py
@@ -409,7 +409,7 @@ class SubnetworksClient(metaclass=SubnetworksClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteSubnetworkRequest, dict] = None,
         *,
@@ -506,7 +506,7 @@ class SubnetworksClient(metaclass=SubnetworksClientMeta):
         # Done; return the response.
         return response
 
-    def expand_ip_cidr_range(
+    def expand_ip_cidr_range_unary(
         self,
         request: Union[compute.ExpandIpCidrRangeSubnetworkRequest, dict] = None,
         *,
@@ -832,7 +832,7 @@ class SubnetworksClient(metaclass=SubnetworksClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertSubnetworkRequest, dict] = None,
         *,
@@ -1084,7 +1084,7 @@ class SubnetworksClient(metaclass=SubnetworksClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchSubnetworkRequest, dict] = None,
         *,
@@ -1327,7 +1327,7 @@ class SubnetworksClient(metaclass=SubnetworksClientMeta):
         # Done; return the response.
         return response
 
-    def set_private_ip_google_access(
+    def set_private_ip_google_access_unary(
         self,
         request: Union[compute.SetPrivateIpGoogleAccessSubnetworkRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/subnetworks/transports/rest.py
+++ b/google/cloud/compute_v1/services/subnetworks/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import SubnetworksTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/target_grpc_proxies/client.py
+++ b/google/cloud/compute_v1/services/target_grpc_proxies/client.py
@@ -342,7 +342,7 @@ class TargetGrpcProxiesClient(metaclass=TargetGrpcProxiesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetGrpcProxyRequest, dict] = None,
         *,
@@ -510,7 +510,7 @@ class TargetGrpcProxiesClient(metaclass=TargetGrpcProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetGrpcProxyRequest, dict] = None,
         *,
@@ -669,7 +669,7 @@ class TargetGrpcProxiesClient(metaclass=TargetGrpcProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchTargetGrpcProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_grpc_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_http_proxies/client.py
+++ b/google/cloud/compute_v1/services/target_http_proxies/client.py
@@ -416,7 +416,7 @@ class TargetHttpProxiesClient(metaclass=TargetHttpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetHttpProxyRequest, dict] = None,
         *,
@@ -590,7 +590,7 @@ class TargetHttpProxiesClient(metaclass=TargetHttpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetHttpProxyRequest, dict] = None,
         *,
@@ -749,7 +749,7 @@ class TargetHttpProxiesClient(metaclass=TargetHttpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchTargetHttpProxyRequest, dict] = None,
         *,
@@ -849,7 +849,7 @@ class TargetHttpProxiesClient(metaclass=TargetHttpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_url_map(
+    def set_url_map_unary(
         self,
         request: Union[compute.SetUrlMapTargetHttpProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_http_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_https_proxies/client.py
+++ b/google/cloud/compute_v1/services/target_https_proxies/client.py
@@ -416,7 +416,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetHttpsProxyRequest, dict] = None,
         *,
@@ -589,7 +589,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetHttpsProxyRequest, dict] = None,
         *,
@@ -749,7 +749,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchTargetHttpsProxyRequest, dict] = None,
         *,
@@ -849,7 +849,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_quic_override(
+    def set_quic_override_unary(
         self,
         request: Union[compute.SetQuicOverrideTargetHttpsProxyRequest, dict] = None,
         *,
@@ -953,7 +953,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_ssl_certificates(
+    def set_ssl_certificates_unary(
         self,
         request: Union[compute.SetSslCertificatesTargetHttpsProxyRequest, dict] = None,
         *,
@@ -1056,7 +1056,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_ssl_policy(
+    def set_ssl_policy_unary(
         self,
         request: Union[compute.SetSslPolicyTargetHttpsProxyRequest, dict] = None,
         *,
@@ -1159,7 +1159,7 @@ class TargetHttpsProxiesClient(metaclass=TargetHttpsProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_url_map(
+    def set_url_map_unary(
         self,
         request: Union[compute.SetUrlMapTargetHttpsProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_https_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_instances/client.py
+++ b/google/cloud/compute_v1/services/target_instances/client.py
@@ -411,7 +411,7 @@ class TargetInstancesClient(metaclass=TargetInstancesClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetInstanceRequest, dict] = None,
         *,
@@ -600,7 +600,7 @@ class TargetInstancesClient(metaclass=TargetInstancesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetInstanceRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_instances/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_instances/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_pools/client.py
+++ b/google/cloud/compute_v1/services/target_pools/client.py
@@ -338,7 +338,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def add_health_check(
+    def add_health_check_unary(
         self,
         request: Union[compute.AddHealthCheckTargetPoolRequest, dict] = None,
         *,
@@ -452,7 +452,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def add_instance(
+    def add_instance_unary(
         self,
         request: Union[compute.AddInstanceTargetPoolRequest, dict] = None,
         *,
@@ -632,7 +632,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetPoolRequest, dict] = None,
         *,
@@ -913,7 +913,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetPoolRequest, dict] = None,
         *,
@@ -1093,7 +1093,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def remove_health_check(
+    def remove_health_check_unary(
         self,
         request: Union[compute.RemoveHealthCheckTargetPoolRequest, dict] = None,
         *,
@@ -1205,7 +1205,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def remove_instance(
+    def remove_instance_unary(
         self,
         request: Union[compute.RemoveInstanceTargetPoolRequest, dict] = None,
         *,
@@ -1319,7 +1319,7 @@ class TargetPoolsClient(metaclass=TargetPoolsClientMeta):
         # Done; return the response.
         return response
 
-    def set_backup(
+    def set_backup_unary(
         self,
         request: Union[compute.SetBackupTargetPoolRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_pools/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_pools/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import TargetPoolsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/target_ssl_proxies/client.py
+++ b/google/cloud/compute_v1/services/target_ssl_proxies/client.py
@@ -340,7 +340,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetSslProxyRequest, dict] = None,
         *,
@@ -509,7 +509,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetSslProxyRequest, dict] = None,
         *,
@@ -669,7 +669,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_backend_service(
+    def set_backend_service_unary(
         self,
         request: Union[compute.SetBackendServiceTargetSslProxyRequest, dict] = None,
         *,
@@ -773,7 +773,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_proxy_header(
+    def set_proxy_header_unary(
         self,
         request: Union[compute.SetProxyHeaderTargetSslProxyRequest, dict] = None,
         *,
@@ -876,7 +876,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_ssl_certificates(
+    def set_ssl_certificates_unary(
         self,
         request: Union[compute.SetSslCertificatesTargetSslProxyRequest, dict] = None,
         *,
@@ -980,7 +980,7 @@ class TargetSslProxiesClient(metaclass=TargetSslProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_ssl_policy(
+    def set_ssl_policy_unary(
         self,
         request: Union[compute.SetSslPolicyTargetSslProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_ssl_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_tcp_proxies/client.py
+++ b/google/cloud/compute_v1/services/target_tcp_proxies/client.py
@@ -340,7 +340,7 @@ class TargetTcpProxiesClient(metaclass=TargetTcpProxiesClientMeta):
                 always_use_jwt_access=True,
             )
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetTcpProxyRequest, dict] = None,
         *,
@@ -509,7 +509,7 @@ class TargetTcpProxiesClient(metaclass=TargetTcpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetTcpProxyRequest, dict] = None,
         *,
@@ -669,7 +669,7 @@ class TargetTcpProxiesClient(metaclass=TargetTcpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_backend_service(
+    def set_backend_service_unary(
         self,
         request: Union[compute.SetBackendServiceTargetTcpProxyRequest, dict] = None,
         *,
@@ -773,7 +773,7 @@ class TargetTcpProxiesClient(metaclass=TargetTcpProxiesClientMeta):
         # Done; return the response.
         return response
 
-    def set_proxy_header(
+    def set_proxy_header_unary(
         self,
         request: Union[compute.SetProxyHeaderTargetTcpProxyRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_tcp_proxies/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/target_vpn_gateways/client.py
+++ b/google/cloud/compute_v1/services/target_vpn_gateways/client.py
@@ -413,7 +413,7 @@ class TargetVpnGatewaysClient(metaclass=TargetVpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteTargetVpnGatewayRequest, dict] = None,
         *,
@@ -595,7 +595,7 @@ class TargetVpnGatewaysClient(metaclass=TargetVpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertTargetVpnGatewayRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
+++ b/google/cloud/compute_v1/services/target_vpn_gateways/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/url_maps/client.py
+++ b/google/cloud/compute_v1/services/url_maps/client.py
@@ -412,7 +412,7 @@ class UrlMapsClient(metaclass=UrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteUrlMapRequest, dict] = None,
         *,
@@ -591,7 +591,7 @@ class UrlMapsClient(metaclass=UrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertUrlMapRequest, dict] = None,
         *,
@@ -676,7 +676,7 @@ class UrlMapsClient(metaclass=UrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def invalidate_cache(
+    def invalidate_cache_unary(
         self,
         request: Union[compute.InvalidateCacheUrlMapRequest, dict] = None,
         *,
@@ -848,7 +848,7 @@ class UrlMapsClient(metaclass=UrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def patch(
+    def patch_unary(
         self,
         request: Union[compute.PatchUrlMapRequest, dict] = None,
         *,
@@ -943,7 +943,7 @@ class UrlMapsClient(metaclass=UrlMapsClientMeta):
         # Done; return the response.
         return response
 
-    def update(
+    def update_unary(
         self,
         request: Union[compute.UpdateUrlMapRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/url_maps/transports/rest.py
+++ b/google/cloud/compute_v1/services/url_maps/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import UrlMapsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/vpn_gateways/client.py
+++ b/google/cloud/compute_v1/services/vpn_gateways/client.py
@@ -409,7 +409,7 @@ class VpnGatewaysClient(metaclass=VpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteVpnGatewayRequest, dict] = None,
         *,
@@ -667,7 +667,7 @@ class VpnGatewaysClient(metaclass=VpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertVpnGatewayRequest, dict] = None,
         *,
@@ -843,7 +843,7 @@ class VpnGatewaysClient(metaclass=VpnGatewaysClientMeta):
         # Done; return the response.
         return response
 
-    def set_labels(
+    def set_labels_unary(
         self,
         request: Union[compute.SetLabelsVpnGatewayRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
+++ b/google/cloud/compute_v1/services/vpn_gateways/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import VpnGatewaysTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/vpn_tunnels/client.py
+++ b/google/cloud/compute_v1/services/vpn_tunnels/client.py
@@ -409,7 +409,7 @@ class VpnTunnelsClient(metaclass=VpnTunnelsClientMeta):
         # Done; return the response.
         return response
 
-    def delete(
+    def delete_unary(
         self,
         request: Union[compute.DeleteVpnTunnelRequest, dict] = None,
         *,
@@ -587,7 +587,7 @@ class VpnTunnelsClient(metaclass=VpnTunnelsClientMeta):
         # Done; return the response.
         return response
 
-    def insert(
+    def insert_unary(
         self,
         request: Union[compute.InsertVpnTunnelRequest, dict] = None,
         *,

--- a/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
+++ b/google/cloud/compute_v1/services/vpn_tunnels/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import VpnTunnelsTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/google/cloud/compute_v1/services/zone_operations/transports/rest.py
+++ b/google/cloud/compute_v1/services/zone_operations/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import (

--- a/google/cloud/compute_v1/services/zones/transports/rest.py
+++ b/google/cloud/compute_v1/services/zones/transports/rest.py
@@ -33,7 +33,6 @@ except AttributeError:  # pragma: NO COVER
 # limitations under the License.
 #
 
-
 from google.cloud.compute_v1.types import compute
 
 from .base import ZonesTransport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -161,7 +161,7 @@ def create_instance(
 
     # Wait for the create operation to complete.
     print(f"Creating the {instance_name} instance in {zone}...")
-    operation = instance_client.insert(request=request)
+    operation = instance_client.insert_unary(request=request)
     while operation.status != compute_v1.Operation.Status.DONE:
         operation = operation_client.wait(
             operation=operation.name, zone=zone, project=project_id
@@ -191,7 +191,7 @@ def delete_instance(project_id: str, zone: str, machine_name: str) -> None:
     operation_client = compute_v1.ZoneOperationsClient()
 
     print(f"Deleting {machine_name} from {zone}...")
-    operation = instance_client.delete(
+    operation = instance_client.delete_unary(
         project=project_id, zone=zone, instance=machine_name
     )
     while operation.status != compute_v1.Operation.Status.DONE:

--- a/samples/snippets/sample_create_vm.py
+++ b/samples/snippets/sample_create_vm.py
@@ -214,7 +214,7 @@ def create_with_disks(
     # Wait for the create operation to complete.
     print(f"Creating the {instance_name} instance in {zone}...")
 
-    operation = instance_client.insert(request=request)
+    operation = instance_client.insert_unary(request=request)
     while operation.status != compute_v1.Operation.Status.DONE:
         operation = operation_client.wait(
             operation=operation.name, zone=zone, project=project_id

--- a/samples/snippets/sample_default_values.py
+++ b/samples/snippets/sample_default_values.py
@@ -58,7 +58,7 @@ def set_usage_export_bucket(
         )
 
     projects_client = compute_v1.ProjectsClient()
-    operation = projects_client.set_usage_export_bucket(
+    operation = projects_client.set_usage_export_bucket_unary(
         project=project_id, usage_export_location_resource=usage_export_location
     )
 
@@ -121,7 +121,7 @@ def disable_usage_export(project_id: str) -> None:
 
     # Setting `usage_export_location_resource` to an
     # empty object will disable the usage report generation.
-    operation = projects_client.set_usage_export_bucket(
+    operation = projects_client.set_usage_export_bucket_unary(
         project=project_id, usage_export_location_resource={}
     )
 

--- a/samples/snippets/sample_firewall.py
+++ b/samples/snippets/sample_firewall.py
@@ -95,7 +95,7 @@ def create_firewall_rule(
     # firewall_rule.priority = 0
 
     firewall_client = compute_v1.FirewallsClient()
-    op = firewall_client.insert(project=project_id, firewall_resource=firewall_rule)
+    op = firewall_client.insert_unary(project=project_id, firewall_resource=firewall_rule)
 
     op_client = compute_v1.GlobalOperationsClient()
     op_client.wait(project=project_id, operation=op.name)
@@ -122,7 +122,7 @@ def patch_firewall_priority(project_id: str, firewall_rule_name: str, priority: 
     # The patch operation doesn't require the full definition of a Firewall object. It will only update
     # the values that were set in it, in this case it will only change the priority.
     firewall_client = compute_v1.FirewallsClient()
-    operation = firewall_client.patch(
+    operation = firewall_client.patch_unary(
         project=project_id, firewall=firewall_rule_name, firewall_resource=firewall_rule
     )
 
@@ -144,7 +144,7 @@ def delete_firewall_rule(project_id: str, firewall_rule_name: str):
         firewall_rule_name: name of the firewall rule you want to delete.
     """
     firewall_client = compute_v1.FirewallsClient()
-    operation = firewall_client.delete(project=project_id, firewall=firewall_rule_name)
+    operation = firewall_client.delete_unary(project=project_id, firewall=firewall_rule_name)
 
     operation_client = compute_v1.GlobalOperationsClient()
     operation_client.wait(project=project_id, operation=operation.name)

--- a/samples/snippets/sample_firewall.py
+++ b/samples/snippets/sample_firewall.py
@@ -95,7 +95,9 @@ def create_firewall_rule(
     # firewall_rule.priority = 0
 
     firewall_client = compute_v1.FirewallsClient()
-    op = firewall_client.insert_unary(project=project_id, firewall_resource=firewall_rule)
+    op = firewall_client.insert_unary(
+        project=project_id, firewall_resource=firewall_rule
+    )
 
     op_client = compute_v1.GlobalOperationsClient()
     op_client.wait(project=project_id, operation=op.name)
@@ -144,7 +146,9 @@ def delete_firewall_rule(project_id: str, firewall_rule_name: str):
         firewall_rule_name: name of the firewall rule you want to delete.
     """
     firewall_client = compute_v1.FirewallsClient()
-    operation = firewall_client.delete_unary(project=project_id, firewall=firewall_rule_name)
+    operation = firewall_client.delete_unary(
+        project=project_id, firewall=firewall_rule_name
+    )
 
     operation_client = compute_v1.GlobalOperationsClient()
     operation_client.wait(project=project_id, operation=operation.name)

--- a/samples/snippets/sample_instance_from_template.py
+++ b/samples/snippets/sample_instance_from_template.py
@@ -48,7 +48,7 @@ def create_instance_from_template(
     instance_insert_request.source_instance_template = instance_template_url
     instance_insert_request.instance_resource.name = instance_name
 
-    op = instance_client.insert(instance_insert_request)
+    op = instance_client.insert_unary(instance_insert_request)
     operation_client.wait(project=project_id, zone=zone, operation=op.name)
 
     return instance_client.get(project=project_id, zone=zone, instance=instance_name)
@@ -127,7 +127,7 @@ def create_instance_from_template_with_overrides(
     instance_insert_request.instance_resource = instance
     instance_insert_request.source_instance_template = instance_template.self_link
 
-    op = instance_client.insert(instance_insert_request)
+    op = instance_client.insert_unary(instance_insert_request)
     operation_client.wait(project=project_id, zone=zone, operation=op.name)
 
     return instance_client.get(project=project_id, zone=zone, instance=instance_name)

--- a/samples/snippets/sample_start_stop.py
+++ b/samples/snippets/sample_start_stop.py
@@ -113,7 +113,9 @@ def stop_instance(project_id: str, zone: str, instance_name: str):
     instance_client = compute_v1.InstancesClient()
     op_client = compute_v1.ZoneOperationsClient()
 
-    op = instance_client.stop_unary(project=project_id, zone=zone, instance=instance_name)
+    op = instance_client.stop_unary(
+        project=project_id, zone=zone, instance=instance_name
+    )
 
     while op.status != compute_v1.Operation.Status.DONE:
         op = op_client.wait(operation=op.name, zone=zone, project=project_id)
@@ -136,7 +138,9 @@ def reset_instance(project_id: str, zone: str, instance_name: str):
     instance_client = compute_v1.InstancesClient()
     op_client = compute_v1.ZoneOperationsClient()
 
-    op = instance_client.reset_unary(project=project_id, zone=zone, instance=instance_name)
+    op = instance_client.reset_unary(
+        project=project_id, zone=zone, instance=instance_name
+    )
 
     while op.status != compute_v1.Operation.Status.DONE:
         op = op_client.wait(operation=op.name, zone=zone, project=project_id)

--- a/samples/snippets/sample_start_stop.py
+++ b/samples/snippets/sample_start_stop.py
@@ -85,7 +85,7 @@ def start_instance_with_encryption_key(
     enc_data = compute_v1.InstancesStartWithEncryptionKeyRequest()
     enc_data.disks = [disk_data]
 
-    op = instance_client.start_with_encryption_key(
+    op = instance_client.start_with_encryption_key_unary(
         project=project_id,
         zone=zone,
         instance=instance_name,
@@ -113,7 +113,7 @@ def stop_instance(project_id: str, zone: str, instance_name: str):
     instance_client = compute_v1.InstancesClient()
     op_client = compute_v1.ZoneOperationsClient()
 
-    op = instance_client.stop(project=project_id, zone=zone, instance=instance_name)
+    op = instance_client.stop_unary(project=project_id, zone=zone, instance=instance_name)
 
     while op.status != compute_v1.Operation.Status.DONE:
         op = op_client.wait(operation=op.name, zone=zone, project=project_id)
@@ -136,7 +136,7 @@ def reset_instance(project_id: str, zone: str, instance_name: str):
     instance_client = compute_v1.InstancesClient()
     op_client = compute_v1.ZoneOperationsClient()
 
-    op = instance_client.reset(project=project_id, zone=zone, instance=instance_name)
+    op = instance_client.reset_unary(project=project_id, zone=zone, instance=instance_name)
 
     while op.status != compute_v1.Operation.Status.DONE:
         op = op_client.wait(operation=op.name, zone=zone, project=project_id)

--- a/samples/snippets/sample_templates.py
+++ b/samples/snippets/sample_templates.py
@@ -118,7 +118,7 @@ def create_template(project_id: str, template_name: str) -> compute_v1.InstanceT
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -162,7 +162,7 @@ def create_template_from_instance(
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -215,7 +215,7 @@ def create_template_with_subnet(
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -235,7 +235,7 @@ def delete_instance_template(project_id: str, template_name: str):
     """
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.delete(project=project_id, instance_template=template_name)
+    op = template_client.delete_unary(project=project_id, instance_template=template_name)
     operation_client.wait(project=project_id, operation=op.name)
     return
 

--- a/samples/snippets/sample_templates.py
+++ b/samples/snippets/sample_templates.py
@@ -118,7 +118,9 @@ def create_template(project_id: str, template_name: str) -> compute_v1.InstanceT
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(
+        project=project_id, instance_template_resource=template
+    )
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -162,7 +164,9 @@ def create_template_from_instance(
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(
+        project=project_id, instance_template_resource=template
+    )
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -215,7 +219,9 @@ def create_template_with_subnet(
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert_unary(project=project_id, instance_template_resource=template)
+    op = template_client.insert_unary(
+        project=project_id, instance_template_resource=template
+    )
     operation_client.wait(project=project_id, operation=op.name)
 
     return template_client.get(project=project_id, instance_template=template_name)
@@ -235,7 +241,9 @@ def delete_instance_template(project_id: str, template_name: str):
     """
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.delete_unary(project=project_id, instance_template=template_name)
+    op = template_client.delete_unary(
+        project=project_id, instance_template=template_name
+    )
     operation_client.wait(project=project_id, operation=op.name)
     return
 

--- a/samples/snippets/test_sample_create_vm.py
+++ b/samples/snippets/test_sample_create_vm.py
@@ -46,7 +46,7 @@ def src_disk(request):
     disk = compute_v1.Disk()
     disk.source_image = get_active_debian().self_link
     disk.name = "test-disk-" + uuid.uuid4().hex[:10]
-    op = disk_client.insert(project=PROJECT, zone=INSTANCE_ZONE, disk_resource=disk)
+    op = disk_client.insert_unary(project=PROJECT, zone=INSTANCE_ZONE, disk_resource=disk)
 
     wait_for_operation(op, PROJECT)
     try:
@@ -54,7 +54,7 @@ def src_disk(request):
         request.cls.disk = disk
         yield disk
     finally:
-        op = disk_client.delete(project=PROJECT, zone=INSTANCE_ZONE, disk=disk.name)
+        op = disk_client.delete_unary(project=PROJECT, zone=INSTANCE_ZONE, disk=disk.name)
         wait_for_operation(op, PROJECT)
 
 
@@ -64,7 +64,7 @@ def snapshot(request, src_disk):
     snapshot = compute_v1.Snapshot()
     snapshot.name = "test-snap-" + uuid.uuid4().hex[:10]
     disk_client = compute_v1.DisksClient()
-    op = disk_client.create_snapshot(
+    op = disk_client.create_snapshot_unary(
         project=PROJECT,
         zone=INSTANCE_ZONE,
         disk=src_disk.name,
@@ -79,7 +79,7 @@ def snapshot(request, src_disk):
 
         yield snapshot
     finally:
-        op = snapshot_client.delete(project=PROJECT, snapshot=snapshot.name)
+        op = snapshot_client.delete_unary(project=PROJECT, snapshot=snapshot.name)
         wait_for_operation(op, PROJECT)
 
 
@@ -89,7 +89,7 @@ def image(request, src_disk):
     image = compute_v1.Image()
     image.source_disk = src_disk.self_link
     image.name = "test-image-" + uuid.uuid4().hex[:10]
-    op = image_client.insert(project=PROJECT, image_resource=image)
+    op = image_client.insert_unary(project=PROJECT, image_resource=image)
 
     wait_for_operation(op, PROJECT)
     try:
@@ -97,7 +97,7 @@ def image(request, src_disk):
         request.cls.image = image
         yield image
     finally:
-        op = image_client.delete(project=PROJECT, image=image.name)
+        op = image_client.delete_unary(project=PROJECT, image=image.name)
         wait_for_operation(op, PROJECT)
 
 

--- a/samples/snippets/test_sample_create_vm.py
+++ b/samples/snippets/test_sample_create_vm.py
@@ -46,7 +46,9 @@ def src_disk(request):
     disk = compute_v1.Disk()
     disk.source_image = get_active_debian().self_link
     disk.name = "test-disk-" + uuid.uuid4().hex[:10]
-    op = disk_client.insert_unary(project=PROJECT, zone=INSTANCE_ZONE, disk_resource=disk)
+    op = disk_client.insert_unary(
+        project=PROJECT, zone=INSTANCE_ZONE, disk_resource=disk
+    )
 
     wait_for_operation(op, PROJECT)
     try:
@@ -54,7 +56,9 @@ def src_disk(request):
         request.cls.disk = disk
         yield disk
     finally:
-        op = disk_client.delete_unary(project=PROJECT, zone=INSTANCE_ZONE, disk=disk.name)
+        op = disk_client.delete_unary(
+            project=PROJECT, zone=INSTANCE_ZONE, disk=disk.name
+        )
         wait_for_operation(op, PROJECT)
 
 

--- a/samples/snippets/test_sample_firewall.py
+++ b/samples/snippets/test_sample_firewall.py
@@ -46,7 +46,7 @@ def firewall_rule():
     firewall_rule.target_tags = ["web"]
 
     firewall_client = compute_v1.FirewallsClient()
-    op = firewall_client.insert(project=PROJECT, firewall_resource=firewall_rule)
+    op = firewall_client.insert_unary(project=PROJECT, firewall_resource=firewall_rule)
 
     op_client = compute_v1.GlobalOperationsClient()
     op_client.wait(project=PROJECT, operation=op.name)
@@ -54,7 +54,7 @@ def firewall_rule():
     yield firewall_client.get(project=PROJECT, firewall=firewall_rule.name)
 
     try:
-        op = firewall_client.delete(project=PROJECT, firewall=firewall_rule.name)
+        op = firewall_client.delete_unary(project=PROJECT, firewall=firewall_rule.name)
         op_client.wait(project=PROJECT, operation=op.name)
     except google.api_core.exceptions.BadRequest as err:
         if err.code == 400 and "is not ready" in err.message:

--- a/samples/snippets/test_sample_instance_from_template.py
+++ b/samples/snippets/test_sample_instance_from_template.py
@@ -51,7 +51,9 @@ def instance_template():
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert_unary(project=PROJECT, instance_template_resource=template)
+    op = template_client.insert_unary(
+        project=PROJECT, instance_template_resource=template
+    )
     operation_client.wait(project=PROJECT, operation=op.name)
 
     template = template_client.get(project=PROJECT, instance_template=template.name)

--- a/samples/snippets/test_sample_instance_from_template.py
+++ b/samples/snippets/test_sample_instance_from_template.py
@@ -51,14 +51,14 @@ def instance_template():
 
     template_client = compute_v1.InstanceTemplatesClient()
     operation_client = compute_v1.GlobalOperationsClient()
-    op = template_client.insert(project=PROJECT, instance_template_resource=template)
+    op = template_client.insert_unary(project=PROJECT, instance_template_resource=template)
     operation_client.wait(project=PROJECT, operation=op.name)
 
     template = template_client.get(project=PROJECT, instance_template=template.name)
 
     yield template
 
-    op = template_client.delete(project=PROJECT, instance_template=template.name)
+    op = template_client.delete_unary(project=PROJECT, instance_template=template.name)
     operation_client.wait(project=PROJECT, operation=op.name)
 
 

--- a/samples/snippets/test_sample_start_stop.py
+++ b/samples/snippets/test_sample_start_stop.py
@@ -83,7 +83,7 @@ def _create_instance(request: compute_v1.InsertInstanceRequest):
     instance_client = compute_v1.InstancesClient()
     operation_client = compute_v1.ZoneOperationsClient()
 
-    operation = instance_client.insert(request=request)
+    operation = instance_client.insert_unary(request=request)
     while operation.status != compute_v1.Operation.Status.DONE:
         operation = operation_client.wait(
             operation=operation.name, zone=INSTANCE_ZONE, project=PROJECT
@@ -98,7 +98,7 @@ def _delete_instance(instance: compute_v1.Instance):
     instance_client = compute_v1.InstancesClient()
     operation_client = compute_v1.ZoneOperationsClient()
 
-    operation = instance_client.delete(
+    operation = instance_client.delete_unary(
         project=PROJECT, zone=INSTANCE_ZONE, instance=instance.name
     )
     while operation.status != compute_v1.Operation.Status.DONE:

--- a/tests/system/test_addresses.py
+++ b/tests/system/test_addresses.py
@@ -26,7 +26,7 @@ class TestAddresses(TestBase):
 
     def tearDown(self) -> None:
         for address in self.addresses:
-            self.client.delete(
+            self.client.delete_unary(
                 project=self.DEFAULT_PROJECT,
                 region=self.DEFAULT_REGION,
                 address=address,
@@ -40,7 +40,7 @@ class TestAddresses(TestBase):
         request.project = self.DEFAULT_PROJECT
         request.region = self.DEFAULT_REGION
         request.address_resource = address_res
-        operation = self.client.insert(request)
+        operation = self.client.insert_unary(request)
         self.wait_for_regional_operation(operation.name)
         self.addresses.append(self.name)
 

--- a/tests/system/test_instance_group.py
+++ b/tests/system/test_instance_group.py
@@ -80,7 +80,7 @@ class TestInstanceGroups(TestBase):
             project=self.DEFAULT_PROJECT,
             instance_resource=instance,
         )
-        operation = self.inst_client.insert(request=request)
+        operation = self.inst_client.insert_unary(request=request)
         self.wait_for_zonal_operation(operation.name)
         self.instances.append(self.name)
 

--- a/tests/system/test_instance_group.py
+++ b/tests/system/test_instance_group.py
@@ -44,18 +44,18 @@ class TestInstanceGroups(TestBase):
 
     def tearDown(self) -> None:
         for igm in self.igms:
-            op = self.igm_client.delete(
+            op = self.igm_client.delete_unary(
                 project=self.DEFAULT_PROJECT,
                 zone=self.DEFAULT_ZONE,
                 instance_group_manager=igm,
             )
             self.wait_for_zonal_operation(op.name)
         for instance in self.instances:
-            op = self.inst_client.delete(
+            op = self.inst_client.delete_unary(
                 project=self.DEFAULT_PROJECT, zone=self.DEFAULT_ZONE, instance=instance
             )
         for template in self.templates:
-            op = self.template_client.delete(
+            op = self.template_client.delete_unary(
                 project=self.DEFAULT_PROJECT, instance_template=template
             )
 
@@ -92,7 +92,7 @@ class TestInstanceGroups(TestBase):
         template_resource = InstanceTemplate(
             name=template_name, source_instance=instance
         )
-        operation = self.template_client.insert(
+        operation = self.template_client.insert_unary(
             project=self.DEFAULT_PROJECT, instance_template_resource=template_resource
         )
         self.wait_for_global_operation(operation.name)
@@ -105,7 +105,7 @@ class TestInstanceGroups(TestBase):
             name=igm_name,
             target_size=0,
         )
-        operation = self.igm_client.insert(
+        operation = self.igm_client.insert_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             instance_group_manager_resource=igm_resource,
@@ -120,7 +120,7 @@ class TestInstanceGroups(TestBase):
         )
         self.assertEqual(instance_group.target_size, 0)
 
-        resize_op = self.igm_client.resize(
+        resize_op = self.igm_client.resize_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             size=1,
@@ -135,7 +135,7 @@ class TestInstanceGroups(TestBase):
         )
         self.assertEqual(instance_group.target_size, 1)
 
-        resize_0_op = self.igm_client.resize(
+        resize_0_op = self.igm_client.resize_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             size=0,

--- a/tests/system/test_smoke.py
+++ b/tests/system/test_smoke.py
@@ -43,7 +43,7 @@ class TestComputeSmoke(TestBase):
 
     def tearDown(self) -> None:
         for instance in self.instances:
-            self.client.delete(
+            self.client.delete_unary(
                 project=self.DEFAULT_PROJECT, zone=self.DEFAULT_ZONE, instance=instance
             )
 
@@ -86,7 +86,7 @@ class TestComputeSmoke(TestBase):
         self.insert_instance()
         instance = self.get_instance()
         self.assertEqual(instance.shielded_instance_config.enable_secure_boot, False)
-        op = self.client.stop(
+        op = self.client.stop_unary(
             project=self.DEFAULT_PROJECT, zone=self.DEFAULT_ZONE, instance=self.name
         )
         self.wait_for_zonal_operation(op.name)
@@ -103,7 +103,7 @@ class TestComputeSmoke(TestBase):
 
         resource = ShieldedInstanceConfig()
         resource.enable_secure_boot = True
-        op = self.client.update_shielded_instance_config(
+        op = self.client.update_shielded_instance_config_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             instance=self.name,
@@ -131,7 +131,7 @@ class TestComputeSmoke(TestBase):
         self.assertEqual(instance.description, "test")
         self.assertEqual(instance.scheduling.min_node_cpus, 0)
         instance.description = ""
-        update_op = self.client.update(
+        update_op = self.client.update_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             instance=self.name,
@@ -147,7 +147,7 @@ class TestComputeSmoke(TestBase):
         instance = self.get_instance()
         self.assertEqual(instance.description, "test")
         instance.description = "тест"
-        update_op = self.client.update(
+        update_op = self.client.update_unary(
             project=self.DEFAULT_PROJECT,
             zone=self.DEFAULT_ZONE,
             instance=self.name,
@@ -190,7 +190,7 @@ class TestComputeSmoke(TestBase):
             project=self.DEFAULT_PROJECT,
             instance_resource=instance,
         )
-        operation = self.client.insert(request=request)
+        operation = self.client.insert_unary(request=request)
         self.wait_for_zonal_operation(operation.name)
         self.instances.append(self.name)
 
@@ -210,7 +210,7 @@ class TestComputeImages(TestBase):
         )
         images_client = ImagesClient(transport="rest")
         request = InsertImageRequest(project=self.DEFAULT_PROJECT, image_resource=image)
-        op = images_client.insert(request)
+        op = images_client.insert_unary(request)
         try:
             self.wait_for_global_operation(op.name)
 
@@ -218,7 +218,7 @@ class TestComputeImages(TestBase):
             self.assertEqual(fetched.license_codes, license_codes)
             self.assertEqual(fetched.name, name)
         finally:
-            images_client.delete(project=self.DEFAULT_PROJECT, image=name)
+            images_client.delete_unary(project=self.DEFAULT_PROJECT, image=name)
 
 
 class TestComputeFirewalls(TestBase):
@@ -234,7 +234,7 @@ class TestComputeFirewalls(TestBase):
             source_ranges=["0.0.0.0/0"],
             allowed=[Allowed(I_p_protocol="tcp", ports=["80"])],
         )
-        op = client.insert(project=self.DEFAULT_PROJECT, firewall_resource=firewall)
+        op = client.insert_unary(project=self.DEFAULT_PROJECT, firewall_resource=firewall)
         try:
             self.wait_for_global_operation(op.name)
 
@@ -242,4 +242,4 @@ class TestComputeFirewalls(TestBase):
             self.assertEqual(fetched.allowed[0].I_p_protocol, "tcp")
             self.assertEqual(fetched.allowed[0].ports, ["80"])
         finally:
-            client.delete(project=self.DEFAULT_PROJECT, firewall=name)
+            client.delete_unary(project=self.DEFAULT_PROJECT, firewall=name)

--- a/tests/system/test_smoke.py
+++ b/tests/system/test_smoke.py
@@ -234,7 +234,9 @@ class TestComputeFirewalls(TestBase):
             source_ranges=["0.0.0.0/0"],
             allowed=[Allowed(I_p_protocol="tcp", ports=["80"])],
         )
-        op = client.insert_unary(project=self.DEFAULT_PROJECT, firewall_resource=firewall)
+        op = client.insert_unary(
+            project=self.DEFAULT_PROJECT, firewall_resource=firewall
+        )
         try:
             self.wait_for_global_operation(op.name)
 

--- a/tests/unit/gapic/compute_v1/test_addresses.py
+++ b/tests/unit/gapic/compute_v1/test_addresses.py
@@ -574,7 +574,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteAddressRequest
 ):
     client = AddressesClient(
@@ -619,7 +619,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -647,7 +647,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteAddressRequest
 ):
     client = AddressesClient(
@@ -667,14 +667,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = AddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -704,7 +704,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", region="region_value", address="address_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -717,7 +717,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = AddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -725,7 +725,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteAddressRequest(),
             project="project_value",
             region="region_value",
@@ -880,7 +880,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertAddressRequest
 ):
     client = AddressesClient(
@@ -926,7 +926,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -954,7 +954,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertAddressRequest
 ):
     client = AddressesClient(
@@ -975,14 +975,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = AddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1010,7 +1010,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             address_resource=compute.Address(address="address_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1023,7 +1023,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = AddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1031,7 +1031,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertAddressRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_autoscalers.py
+++ b/tests/unit/gapic/compute_v1/test_autoscalers.py
@@ -581,7 +581,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -626,7 +626,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -654,7 +654,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -674,14 +674,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -711,7 +711,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", autoscaler="autoscaler_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -724,7 +724,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -732,7 +732,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteAutoscalerRequest(),
             project="project_value",
             zone="zone_value",
@@ -875,7 +875,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -923,7 +923,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -951,7 +951,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -974,14 +974,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1011,7 +1011,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1024,7 +1024,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1032,7 +1032,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertAutoscalerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1207,7 +1207,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -1255,7 +1255,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1283,7 +1283,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -1306,14 +1306,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1343,7 +1343,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1356,7 +1356,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1364,7 +1364,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchAutoscalerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1374,7 +1374,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -1422,7 +1422,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1450,7 +1450,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateAutoscalerRequest
 ):
     client = AutoscalersClient(
@@ -1473,14 +1473,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1510,7 +1510,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1523,7 +1523,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = AutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1531,7 +1531,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateAutoscalerRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_backend_buckets.py
+++ b/tests/unit/gapic/compute_v1/test_backend_buckets.py
@@ -409,7 +409,7 @@ def test_backend_buckets_client_client_options_credentials_file(
         )
 
 
-def test_add_signed_url_key_rest(
+def test_add_signed_url_key_unary_rest(
     transport: str = "rest", request_type=compute.AddSignedUrlKeyBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -457,7 +457,7 @@ def test_add_signed_url_key_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_signed_url_key(request)
+        response = client.add_signed_url_key_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -485,7 +485,7 @@ def test_add_signed_url_key_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_signed_url_key_rest_bad_request(
+def test_add_signed_url_key_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddSignedUrlKeyBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -508,14 +508,14 @@ def test_add_signed_url_key_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_signed_url_key(request)
+        client.add_signed_url_key_unary(request)
 
 
-def test_add_signed_url_key_rest_from_dict():
-    test_add_signed_url_key_rest(request_type=dict)
+def test_add_signed_url_key_unary_rest_from_dict():
+    test_add_signed_url_key_unary_rest(request_type=dict)
 
 
-def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
+def test_add_signed_url_key_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -543,7 +543,7 @@ def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
             signed_url_key_resource=compute.SignedUrlKey(key_name="key_name_value"),
         )
         mock_args.update(sample_request)
-        client.add_signed_url_key(**mock_args)
+        client.add_signed_url_key_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -556,7 +556,7 @@ def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_signed_url_key_rest_flattened_error(transport: str = "rest"):
+def test_add_signed_url_key_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -564,7 +564,7 @@ def test_add_signed_url_key_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_signed_url_key(
+        client.add_signed_url_key_unary(
             compute.AddSignedUrlKeyBackendBucketRequest(),
             project="project_value",
             backend_bucket="backend_bucket_value",
@@ -572,7 +572,7 @@ def test_add_signed_url_key_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -617,7 +617,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -645,7 +645,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -665,14 +665,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -698,7 +698,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", backend_bucket="backend_bucket_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -711,7 +711,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -719,14 +719,14 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteBackendBucketRequest(),
             project="project_value",
             backend_bucket="backend_bucket_value",
         )
 
 
-def test_delete_signed_url_key_rest(
+def test_delete_signed_url_key_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSignedUrlKeyBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -771,7 +771,7 @@ def test_delete_signed_url_key_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_signed_url_key(request)
+        response = client.delete_signed_url_key_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -799,7 +799,7 @@ def test_delete_signed_url_key_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_signed_url_key_rest_bad_request(
+def test_delete_signed_url_key_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSignedUrlKeyBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -819,14 +819,14 @@ def test_delete_signed_url_key_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_signed_url_key(request)
+        client.delete_signed_url_key_unary(request)
 
 
-def test_delete_signed_url_key_rest_from_dict():
-    test_delete_signed_url_key_rest(request_type=dict)
+def test_delete_signed_url_key_unary_rest_from_dict():
+    test_delete_signed_url_key_unary_rest(request_type=dict)
 
 
-def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
+def test_delete_signed_url_key_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -854,7 +854,7 @@ def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
             key_name="key_name_value",
         )
         mock_args.update(sample_request)
-        client.delete_signed_url_key(**mock_args)
+        client.delete_signed_url_key_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -867,7 +867,7 @@ def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_signed_url_key_rest_flattened_error(transport: str = "rest"):
+def test_delete_signed_url_key_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -875,7 +875,7 @@ def test_delete_signed_url_key_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_signed_url_key(
+        client.delete_signed_url_key_unary(
             compute.DeleteSignedUrlKeyBackendBucketRequest(),
             project="project_value",
             backend_bucket="backend_bucket_value",
@@ -1011,7 +1011,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1059,7 +1059,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1087,7 +1087,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1110,14 +1110,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1146,7 +1146,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1159,7 +1159,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1167,7 +1167,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertBackendBucketRequest(),
             project="project_value",
             backend_bucket_resource=compute.BackendBucket(
@@ -1339,7 +1339,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1387,7 +1387,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1415,7 +1415,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1438,14 +1438,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1475,7 +1475,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1488,7 +1488,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1496,7 +1496,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchBackendBucketRequest(),
             project="project_value",
             backend_bucket="backend_bucket_value",
@@ -1506,7 +1506,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1554,7 +1554,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1582,7 +1582,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateBackendBucketRequest
 ):
     client = BackendBucketsClient(
@@ -1605,14 +1605,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1642,7 +1642,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1655,7 +1655,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendBucketsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1663,7 +1663,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateBackendBucketRequest(),
             project="project_value",
             backend_bucket="backend_bucket_value",

--- a/tests/unit/gapic/compute_v1/test_backend_services.py
+++ b/tests/unit/gapic/compute_v1/test_backend_services.py
@@ -419,7 +419,7 @@ def test_backend_services_client_client_options_credentials_file(
         )
 
 
-def test_add_signed_url_key_rest(
+def test_add_signed_url_key_unary_rest(
     transport: str = "rest", request_type=compute.AddSignedUrlKeyBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -467,7 +467,7 @@ def test_add_signed_url_key_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_signed_url_key(request)
+        response = client.add_signed_url_key_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -495,7 +495,7 @@ def test_add_signed_url_key_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_signed_url_key_rest_bad_request(
+def test_add_signed_url_key_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddSignedUrlKeyBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -518,14 +518,14 @@ def test_add_signed_url_key_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_signed_url_key(request)
+        client.add_signed_url_key_unary(request)
 
 
-def test_add_signed_url_key_rest_from_dict():
-    test_add_signed_url_key_rest(request_type=dict)
+def test_add_signed_url_key_unary_rest_from_dict():
+    test_add_signed_url_key_unary_rest(request_type=dict)
 
 
-def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
+def test_add_signed_url_key_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -553,7 +553,7 @@ def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
             signed_url_key_resource=compute.SignedUrlKey(key_name="key_name_value"),
         )
         mock_args.update(sample_request)
-        client.add_signed_url_key(**mock_args)
+        client.add_signed_url_key_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -566,7 +566,7 @@ def test_add_signed_url_key_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_signed_url_key_rest_flattened_error(transport: str = "rest"):
+def test_add_signed_url_key_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -574,7 +574,7 @@ def test_add_signed_url_key_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_signed_url_key(
+        client.add_signed_url_key_unary(
             compute.AddSignedUrlKeyBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",
@@ -765,7 +765,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -810,7 +810,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -838,7 +838,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -858,14 +858,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -891,7 +891,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", backend_service="backend_service_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -904,7 +904,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -912,14 +912,14 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",
         )
 
 
-def test_delete_signed_url_key_rest(
+def test_delete_signed_url_key_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteSignedUrlKeyBackendServiceRequest,
 ):
@@ -965,7 +965,7 @@ def test_delete_signed_url_key_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_signed_url_key(request)
+        response = client.delete_signed_url_key_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -993,7 +993,7 @@ def test_delete_signed_url_key_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_signed_url_key_rest_bad_request(
+def test_delete_signed_url_key_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteSignedUrlKeyBackendServiceRequest,
 ):
@@ -1014,14 +1014,14 @@ def test_delete_signed_url_key_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_signed_url_key(request)
+        client.delete_signed_url_key_unary(request)
 
 
-def test_delete_signed_url_key_rest_from_dict():
-    test_delete_signed_url_key_rest(request_type=dict)
+def test_delete_signed_url_key_unary_rest_from_dict():
+    test_delete_signed_url_key_unary_rest(request_type=dict)
 
 
-def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
+def test_delete_signed_url_key_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1049,7 +1049,7 @@ def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
             key_name="key_name_value",
         )
         mock_args.update(sample_request)
-        client.delete_signed_url_key(**mock_args)
+        client.delete_signed_url_key_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1062,7 +1062,7 @@ def test_delete_signed_url_key_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_signed_url_key_rest_flattened_error(transport: str = "rest"):
+def test_delete_signed_url_key_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1070,7 +1070,7 @@ def test_delete_signed_url_key_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_signed_url_key(
+        client.delete_signed_url_key_unary(
             compute.DeleteSignedUrlKeyBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",
@@ -1355,7 +1355,7 @@ def test_get_health_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1403,7 +1403,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1431,7 +1431,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1454,14 +1454,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1490,7 +1490,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1503,7 +1503,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1511,7 +1511,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertBackendServiceRequest(),
             project="project_value",
             backend_service_resource=compute.BackendService(
@@ -1683,7 +1683,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1731,7 +1731,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1759,7 +1759,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1782,14 +1782,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1819,7 +1819,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1832,7 +1832,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1840,7 +1840,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",
@@ -1850,7 +1850,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_security_policy_rest(
+def test_set_security_policy_unary_rest(
     transport: str = "rest", request_type=compute.SetSecurityPolicyBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1898,7 +1898,7 @@ def test_set_security_policy_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_security_policy(request)
+        response = client.set_security_policy_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1926,7 +1926,7 @@ def test_set_security_policy_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_security_policy_rest_bad_request(
+def test_set_security_policy_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetSecurityPolicyBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -1949,14 +1949,14 @@ def test_set_security_policy_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_security_policy(request)
+        client.set_security_policy_unary(request)
 
 
-def test_set_security_policy_rest_from_dict():
-    test_set_security_policy_rest(request_type=dict)
+def test_set_security_policy_unary_rest_from_dict():
+    test_set_security_policy_unary_rest(request_type=dict)
 
 
-def test_set_security_policy_rest_flattened(transport: str = "rest"):
+def test_set_security_policy_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1986,7 +1986,7 @@ def test_set_security_policy_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_security_policy(**mock_args)
+        client.set_security_policy_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1999,7 +1999,7 @@ def test_set_security_policy_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_security_policy_rest_flattened_error(transport: str = "rest"):
+def test_set_security_policy_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2007,7 +2007,7 @@ def test_set_security_policy_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_security_policy(
+        client.set_security_policy_unary(
             compute.SetSecurityPolicyBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",
@@ -2017,7 +2017,7 @@ def test_set_security_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -2065,7 +2065,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2093,7 +2093,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateBackendServiceRequest
 ):
     client = BackendServicesClient(
@@ -2116,14 +2116,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2153,7 +2153,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2166,7 +2166,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = BackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2174,7 +2174,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateBackendServiceRequest(),
             project="project_value",
             backend_service="backend_service_value",

--- a/tests/unit/gapic/compute_v1/test_disks.py
+++ b/tests/unit/gapic/compute_v1/test_disks.py
@@ -394,7 +394,7 @@ def test_disks_client_client_options_credentials_file(
         )
 
 
-def test_add_resource_policies_rest(
+def test_add_resource_policies_unary_rest(
     transport: str = "rest", request_type=compute.AddResourcePoliciesDiskRequest
 ):
     client = DisksClient(
@@ -444,7 +444,7 @@ def test_add_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_resource_policies(request)
+        response = client.add_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -472,7 +472,7 @@ def test_add_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_resource_policies_rest_bad_request(
+def test_add_resource_policies_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddResourcePoliciesDiskRequest
 ):
     client = DisksClient(
@@ -497,14 +497,14 @@ def test_add_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_resource_policies(request)
+        client.add_resource_policies_unary(request)
 
 
-def test_add_resource_policies_rest_from_dict():
-    test_add_resource_policies_rest(request_type=dict)
+def test_add_resource_policies_unary_rest_from_dict():
+    test_add_resource_policies_unary_rest(request_type=dict)
 
 
-def test_add_resource_policies_rest_flattened(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -535,7 +535,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_resource_policies(**mock_args)
+        client.add_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -548,7 +548,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -556,7 +556,7 @@ def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_resource_policies(
+        client.add_resource_policies_unary(
             compute.AddResourcePoliciesDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -741,7 +741,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_create_snapshot_rest(
+def test_create_snapshot_unary_rest(
     transport: str = "rest", request_type=compute.CreateSnapshotDiskRequest
 ):
     client = DisksClient(
@@ -787,7 +787,7 @@ def test_create_snapshot_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.create_snapshot(request)
+        response = client.create_snapshot_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -815,7 +815,7 @@ def test_create_snapshot_rest(
     assert response.zone == "zone_value"
 
 
-def test_create_snapshot_rest_bad_request(
+def test_create_snapshot_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.CreateSnapshotDiskRequest
 ):
     client = DisksClient(
@@ -836,14 +836,14 @@ def test_create_snapshot_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.create_snapshot(request)
+        client.create_snapshot_unary(request)
 
 
-def test_create_snapshot_rest_from_dict():
-    test_create_snapshot_rest(request_type=dict)
+def test_create_snapshot_unary_rest_from_dict():
+    test_create_snapshot_unary_rest(request_type=dict)
 
 
-def test_create_snapshot_rest_flattened(transport: str = "rest"):
+def test_create_snapshot_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -872,7 +872,7 @@ def test_create_snapshot_rest_flattened(transport: str = "rest"):
             snapshot_resource=compute.Snapshot(auto_created=True),
         )
         mock_args.update(sample_request)
-        client.create_snapshot(**mock_args)
+        client.create_snapshot_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -885,7 +885,7 @@ def test_create_snapshot_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
+def test_create_snapshot_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -893,7 +893,7 @@ def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.create_snapshot(
+        client.create_snapshot_unary(
             compute.CreateSnapshotDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -902,7 +902,9 @@ def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(transport: str = "rest", request_type=compute.DeleteDiskRequest):
+def test_delete_unary_rest(
+    transport: str = "rest", request_type=compute.DeleteDiskRequest
+):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -945,7 +947,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteDiskReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -973,7 +975,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteDiskReq
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteDiskRequest
 ):
     client = DisksClient(
@@ -993,14 +995,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1024,7 +1026,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", zone="zone_value", disk="disk_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1037,7 +1039,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1045,7 +1047,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -1339,7 +1341,9 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(transport: str = "rest", request_type=compute.InsertDiskRequest):
+def test_insert_unary_rest(
+    transport: str = "rest", request_type=compute.InsertDiskRequest
+):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1385,7 +1389,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertDiskReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1413,7 +1417,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertDiskReq
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertDiskRequest
 ):
     client = DisksClient(
@@ -1436,14 +1440,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1471,7 +1475,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             disk_resource=compute.Disk(creation_timestamp="creation_timestamp_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1484,7 +1488,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1492,7 +1496,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -1653,7 +1657,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_remove_resource_policies_rest(
+def test_remove_resource_policies_unary_rest(
     transport: str = "rest", request_type=compute.RemoveResourcePoliciesDiskRequest
 ):
     client = DisksClient(
@@ -1703,7 +1707,7 @@ def test_remove_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_resource_policies(request)
+        response = client.remove_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1731,7 +1735,7 @@ def test_remove_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_resource_policies_rest_bad_request(
+def test_remove_resource_policies_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveResourcePoliciesDiskRequest
 ):
     client = DisksClient(
@@ -1756,14 +1760,14 @@ def test_remove_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_resource_policies(request)
+        client.remove_resource_policies_unary(request)
 
 
-def test_remove_resource_policies_rest_from_dict():
-    test_remove_resource_policies_rest(request_type=dict)
+def test_remove_resource_policies_unary_rest_from_dict():
+    test_remove_resource_policies_unary_rest(request_type=dict)
 
 
-def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1794,7 +1798,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_resource_policies(**mock_args)
+        client.remove_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1807,7 +1811,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1815,7 +1819,7 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_resource_policies(
+        client.remove_resource_policies_unary(
             compute.RemoveResourcePoliciesDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -1826,7 +1830,9 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_resize_rest(transport: str = "rest", request_type=compute.ResizeDiskRequest):
+def test_resize_unary_rest(
+    transport: str = "rest", request_type=compute.ResizeDiskRequest
+):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1872,7 +1878,7 @@ def test_resize_rest(transport: str = "rest", request_type=compute.ResizeDiskReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.resize(request)
+        response = client.resize_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1900,7 +1906,7 @@ def test_resize_rest(transport: str = "rest", request_type=compute.ResizeDiskReq
     assert response.zone == "zone_value"
 
 
-def test_resize_rest_bad_request(
+def test_resize_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ResizeDiskRequest
 ):
     client = DisksClient(
@@ -1923,14 +1929,14 @@ def test_resize_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.resize(request)
+        client.resize_unary(request)
 
 
-def test_resize_rest_from_dict():
-    test_resize_rest(request_type=dict)
+def test_resize_unary_rest_from_dict():
+    test_resize_unary_rest(request_type=dict)
 
 
-def test_resize_rest_flattened(transport: str = "rest"):
+def test_resize_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1959,7 +1965,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
             disks_resize_request_resource=compute.DisksResizeRequest(size_gb=739),
         )
         mock_args.update(sample_request)
-        client.resize(**mock_args)
+        client.resize_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1972,7 +1978,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_resize_rest_flattened_error(transport: str = "rest"):
+def test_resize_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1980,7 +1986,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.resize(
+        client.resize_unary(
             compute.ResizeDiskRequest(),
             project="project_value",
             zone="zone_value",
@@ -2120,7 +2126,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsDiskRequest
 ):
     client = DisksClient(
@@ -2168,7 +2174,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2196,7 +2202,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsDiskRequest
 ):
     client = DisksClient(
@@ -2219,14 +2225,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2261,7 +2267,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2274,7 +2280,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = DisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2282,7 +2288,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsDiskRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_external_vpn_gateways.py
+++ b/tests/unit/gapic/compute_v1/test_external_vpn_gateways.py
@@ -422,7 +422,7 @@ def test_external_vpn_gateways_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -467,7 +467,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -495,7 +495,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -515,14 +515,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -548,7 +548,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", external_vpn_gateway="external_vpn_gateway_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -561,7 +561,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -569,7 +569,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteExternalVpnGatewayRequest(),
             project="project_value",
             external_vpn_gateway="external_vpn_gateway_value",
@@ -702,7 +702,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -750,7 +750,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -778,7 +778,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -801,14 +801,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -837,7 +837,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -850,7 +850,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -858,7 +858,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertExternalVpnGatewayRequest(),
             project="project_value",
             external_vpn_gateway_resource=compute.ExternalVpnGateway(
@@ -1034,7 +1034,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -1082,7 +1082,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1110,7 +1110,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsExternalVpnGatewayRequest
 ):
     client = ExternalVpnGatewaysClient(
@@ -1133,14 +1133,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1170,7 +1170,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1183,7 +1183,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = ExternalVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1191,7 +1191,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsExternalVpnGatewayRequest(),
             project="project_value",
             resource="resource_value",

--- a/tests/unit/gapic/compute_v1/test_firewall_policies.py
+++ b/tests/unit/gapic/compute_v1/test_firewall_policies.py
@@ -420,7 +420,7 @@ def test_firewall_policies_client_client_options_credentials_file(
         )
 
 
-def test_add_association_rest(
+def test_add_association_unary_rest(
     transport: str = "rest", request_type=compute.AddAssociationFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -468,7 +468,7 @@ def test_add_association_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_association(request)
+        response = client.add_association_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -496,7 +496,7 @@ def test_add_association_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_association_rest_bad_request(
+def test_add_association_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddAssociationFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -519,14 +519,14 @@ def test_add_association_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_association(request)
+        client.add_association_unary(request)
 
 
-def test_add_association_rest_from_dict():
-    test_add_association_rest(request_type=dict)
+def test_add_association_unary_rest_from_dict():
+    test_add_association_unary_rest(request_type=dict)
 
 
-def test_add_association_rest_flattened(transport: str = "rest"):
+def test_add_association_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -555,7 +555,7 @@ def test_add_association_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_association(**mock_args)
+        client.add_association_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -568,7 +568,7 @@ def test_add_association_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_association_rest_flattened_error(transport: str = "rest"):
+def test_add_association_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -576,7 +576,7 @@ def test_add_association_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_association(
+        client.add_association_unary(
             compute.AddAssociationFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
             firewall_policy_association_resource=compute.FirewallPolicyAssociation(
@@ -585,7 +585,7 @@ def test_add_association_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_add_rule_rest(
+def test_add_rule_unary_rest(
     transport: str = "rest", request_type=compute.AddRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -633,7 +633,7 @@ def test_add_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_rule(request)
+        response = client.add_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -661,7 +661,7 @@ def test_add_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_rule_rest_bad_request(
+def test_add_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -684,14 +684,14 @@ def test_add_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_rule(request)
+        client.add_rule_unary(request)
 
 
-def test_add_rule_rest_from_dict():
-    test_add_rule_rest(request_type=dict)
+def test_add_rule_unary_rest_from_dict():
+    test_add_rule_unary_rest(request_type=dict)
 
 
-def test_add_rule_rest_flattened(transport: str = "rest"):
+def test_add_rule_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -720,7 +720,7 @@ def test_add_rule_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_rule(**mock_args)
+        client.add_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -733,7 +733,7 @@ def test_add_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_rule_rest_flattened_error(transport: str = "rest"):
+def test_add_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -741,7 +741,7 @@ def test_add_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_rule(
+        client.add_rule_unary(
             compute.AddRuleFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
             firewall_policy_rule_resource=compute.FirewallPolicyRule(
@@ -750,7 +750,7 @@ def test_add_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_clone_rules_rest(
+def test_clone_rules_unary_rest(
     transport: str = "rest", request_type=compute.CloneRulesFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -795,7 +795,7 @@ def test_clone_rules_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.clone_rules(request)
+        response = client.clone_rules_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -823,7 +823,7 @@ def test_clone_rules_rest(
     assert response.zone == "zone_value"
 
 
-def test_clone_rules_rest_bad_request(
+def test_clone_rules_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.CloneRulesFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -843,14 +843,14 @@ def test_clone_rules_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.clone_rules(request)
+        client.clone_rules_unary(request)
 
 
-def test_clone_rules_rest_from_dict():
-    test_clone_rules_rest(request_type=dict)
+def test_clone_rules_unary_rest_from_dict():
+    test_clone_rules_unary_rest(request_type=dict)
 
 
-def test_clone_rules_rest_flattened(transport: str = "rest"):
+def test_clone_rules_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -874,7 +874,7 @@ def test_clone_rules_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(firewall_policy="firewall_policy_value",)
         mock_args.update(sample_request)
-        client.clone_rules(**mock_args)
+        client.clone_rules_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -887,7 +887,7 @@ def test_clone_rules_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_clone_rules_rest_flattened_error(transport: str = "rest"):
+def test_clone_rules_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -895,13 +895,13 @@ def test_clone_rules_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.clone_rules(
+        client.clone_rules_unary(
             compute.CloneRulesFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -946,7 +946,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -974,7 +974,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -994,14 +994,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1025,7 +1025,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(firewall_policy="firewall_policy_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1038,7 +1038,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1046,7 +1046,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
         )
@@ -1534,7 +1534,7 @@ def test_get_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -1586,7 +1586,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1614,7 +1614,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -1641,14 +1641,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1681,7 +1681,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1694,7 +1694,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1702,7 +1702,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertFirewallPolicyRequest(),
             parent_id="parent_id_value",
             firewall_policy_resource=compute.FirewallPolicy(
@@ -1884,7 +1884,7 @@ def test_list_associations_rest_from_dict():
     test_list_associations_rest(request_type=dict)
 
 
-def test_move_rest(
+def test_move_unary_rest(
     transport: str = "rest", request_type=compute.MoveFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -1929,7 +1929,7 @@ def test_move_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.move(request)
+        response = client.move_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1957,7 +1957,7 @@ def test_move_rest(
     assert response.zone == "zone_value"
 
 
-def test_move_rest_bad_request(
+def test_move_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.MoveFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -1977,14 +1977,14 @@ def test_move_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.move(request)
+        client.move_unary(request)
 
 
-def test_move_rest_from_dict():
-    test_move_rest(request_type=dict)
+def test_move_unary_rest_from_dict():
+    test_move_unary_rest(request_type=dict)
 
 
-def test_move_rest_flattened(transport: str = "rest"):
+def test_move_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2010,7 +2010,7 @@ def test_move_rest_flattened(transport: str = "rest"):
             firewall_policy="firewall_policy_value", parent_id="parent_id_value",
         )
         mock_args.update(sample_request)
-        client.move(**mock_args)
+        client.move_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2023,7 +2023,7 @@ def test_move_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_move_rest_flattened_error(transport: str = "rest"):
+def test_move_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2031,14 +2031,14 @@ def test_move_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.move(
+        client.move_unary(
             compute.MoveFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
             parent_id="parent_id_value",
         )
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2090,7 +2090,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2118,7 +2118,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2145,14 +2145,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2185,7 +2185,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2198,7 +2198,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2206,7 +2206,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
             firewall_policy_resource=compute.FirewallPolicy(
@@ -2219,7 +2219,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_patch_rule_rest(
+def test_patch_rule_unary_rest(
     transport: str = "rest", request_type=compute.PatchRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2267,7 +2267,7 @@ def test_patch_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch_rule(request)
+        response = client.patch_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2295,7 +2295,7 @@ def test_patch_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rule_rest_bad_request(
+def test_patch_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2318,14 +2318,14 @@ def test_patch_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch_rule(request)
+        client.patch_rule_unary(request)
 
 
-def test_patch_rule_rest_from_dict():
-    test_patch_rule_rest(request_type=dict)
+def test_patch_rule_unary_rest_from_dict():
+    test_patch_rule_unary_rest(request_type=dict)
 
 
-def test_patch_rule_rest_flattened(transport: str = "rest"):
+def test_patch_rule_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2354,7 +2354,7 @@ def test_patch_rule_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch_rule(**mock_args)
+        client.patch_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2367,7 +2367,7 @@ def test_patch_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rule_rest_flattened_error(transport: str = "rest"):
+def test_patch_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2375,7 +2375,7 @@ def test_patch_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch_rule(
+        client.patch_rule_unary(
             compute.PatchRuleFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
             firewall_policy_rule_resource=compute.FirewallPolicyRule(
@@ -2384,7 +2384,7 @@ def test_patch_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_remove_association_rest(
+def test_remove_association_unary_rest(
     transport: str = "rest", request_type=compute.RemoveAssociationFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2429,7 +2429,7 @@ def test_remove_association_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_association(request)
+        response = client.remove_association_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2457,7 +2457,7 @@ def test_remove_association_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_association_rest_bad_request(
+def test_remove_association_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveAssociationFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2477,14 +2477,14 @@ def test_remove_association_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_association(request)
+        client.remove_association_unary(request)
 
 
-def test_remove_association_rest_from_dict():
-    test_remove_association_rest(request_type=dict)
+def test_remove_association_unary_rest_from_dict():
+    test_remove_association_unary_rest(request_type=dict)
 
 
-def test_remove_association_rest_flattened(transport: str = "rest"):
+def test_remove_association_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2508,7 +2508,7 @@ def test_remove_association_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(firewall_policy="firewall_policy_value",)
         mock_args.update(sample_request)
-        client.remove_association(**mock_args)
+        client.remove_association_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2521,7 +2521,7 @@ def test_remove_association_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_association_rest_flattened_error(transport: str = "rest"):
+def test_remove_association_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2529,13 +2529,13 @@ def test_remove_association_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_association(
+        client.remove_association_unary(
             compute.RemoveAssociationFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
         )
 
 
-def test_remove_rule_rest(
+def test_remove_rule_unary_rest(
     transport: str = "rest", request_type=compute.RemoveRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2580,7 +2580,7 @@ def test_remove_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_rule(request)
+        response = client.remove_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2608,7 +2608,7 @@ def test_remove_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_rule_rest_bad_request(
+def test_remove_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveRuleFirewallPolicyRequest
 ):
     client = FirewallPoliciesClient(
@@ -2628,14 +2628,14 @@ def test_remove_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_rule(request)
+        client.remove_rule_unary(request)
 
 
-def test_remove_rule_rest_from_dict():
-    test_remove_rule_rest(request_type=dict)
+def test_remove_rule_unary_rest_from_dict():
+    test_remove_rule_unary_rest(request_type=dict)
 
 
-def test_remove_rule_rest_flattened(transport: str = "rest"):
+def test_remove_rule_unary_rest_flattened(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2659,7 +2659,7 @@ def test_remove_rule_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(firewall_policy="firewall_policy_value",)
         mock_args.update(sample_request)
-        client.remove_rule(**mock_args)
+        client.remove_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2672,7 +2672,7 @@ def test_remove_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_rule_rest_flattened_error(transport: str = "rest"):
+def test_remove_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2680,7 +2680,7 @@ def test_remove_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_rule(
+        client.remove_rule_unary(
             compute.RemoveRuleFirewallPolicyRequest(),
             firewall_policy="firewall_policy_value",
         )

--- a/tests/unit/gapic/compute_v1/test_firewalls.py
+++ b/tests/unit/gapic/compute_v1/test_firewalls.py
@@ -397,7 +397,7 @@ def test_firewalls_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteFirewallRequest
 ):
     client = FirewallsClient(
@@ -442,7 +442,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -470,7 +470,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteFirewallRequest
 ):
     client = FirewallsClient(
@@ -490,14 +490,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -521,7 +521,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", firewall="firewall_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -534,7 +534,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,7 +542,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteFirewallRequest(),
             project="project_value",
             firewall="firewall_value",
@@ -687,7 +687,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertFirewallRequest
 ):
     client = FirewallsClient(
@@ -735,7 +735,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -763,7 +763,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertFirewallRequest
 ):
     client = FirewallsClient(
@@ -786,14 +786,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -822,7 +822,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -835,7 +835,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -843,7 +843,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertFirewallRequest(),
             project="project_value",
             firewall_resource=compute.Firewall(
@@ -1005,7 +1005,9 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(transport: str = "rest", request_type=compute.PatchFirewallRequest):
+def test_patch_unary_rest(
+    transport: str = "rest", request_type=compute.PatchFirewallRequest
+):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1051,7 +1053,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchFirewallR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1079,7 +1081,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchFirewallR
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchFirewallRequest
 ):
     client = FirewallsClient(
@@ -1102,14 +1104,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1139,7 +1141,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1152,7 +1154,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1160,7 +1162,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchFirewallRequest(),
             project="project_value",
             firewall="firewall_value",
@@ -1170,7 +1172,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateFirewallRequest
 ):
     client = FirewallsClient(
@@ -1218,7 +1220,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1246,7 +1248,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateFirewallRequest
 ):
     client = FirewallsClient(
@@ -1269,14 +1271,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1306,7 +1308,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1319,7 +1321,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = FirewallsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1327,7 +1329,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateFirewallRequest(),
             project="project_value",
             firewall="firewall_value",

--- a/tests/unit/gapic/compute_v1/test_forwarding_rules.py
+++ b/tests/unit/gapic/compute_v1/test_forwarding_rules.py
@@ -602,7 +602,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -651,7 +651,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -679,7 +679,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -703,14 +703,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -742,7 +742,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             forwarding_rule="forwarding_rule_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -755,7 +755,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -763,7 +763,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteForwardingRuleRequest(),
             project="project_value",
             region="region_value",
@@ -950,7 +950,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -998,7 +998,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1026,7 +1026,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1049,14 +1049,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1086,7 +1086,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1099,7 +1099,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1107,7 +1107,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertForwardingRuleRequest(),
             project="project_value",
             region="region_value",
@@ -1282,7 +1282,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1334,7 +1334,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1362,7 +1362,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1389,14 +1389,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1431,7 +1431,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1444,7 +1444,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1452,7 +1452,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchForwardingRuleRequest(),
             project="project_value",
             region="region_value",
@@ -1463,7 +1463,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1511,7 +1511,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1539,7 +1539,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1562,14 +1562,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1604,7 +1604,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1617,7 +1617,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1625,7 +1625,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsForwardingRuleRequest(),
             project="project_value",
             region="region_value",
@@ -1636,7 +1636,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_target_rest(
+def test_set_target_unary_rest(
     transport: str = "rest", request_type=compute.SetTargetForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1688,7 +1688,7 @@ def test_set_target_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_target(request)
+        response = client.set_target_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1716,7 +1716,7 @@ def test_set_target_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_target_rest_bad_request(
+def test_set_target_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetTargetForwardingRuleRequest
 ):
     client = ForwardingRulesClient(
@@ -1743,14 +1743,14 @@ def test_set_target_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_target(request)
+        client.set_target_unary(request)
 
 
-def test_set_target_rest_from_dict():
-    test_set_target_rest(request_type=dict)
+def test_set_target_unary_rest_from_dict():
+    test_set_target_unary_rest(request_type=dict)
 
 
-def test_set_target_rest_flattened(transport: str = "rest"):
+def test_set_target_unary_rest_flattened(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1783,7 +1783,7 @@ def test_set_target_rest_flattened(transport: str = "rest"):
             target_reference_resource=compute.TargetReference(target="target_value"),
         )
         mock_args.update(sample_request)
-        client.set_target(**mock_args)
+        client.set_target_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1796,7 +1796,7 @@ def test_set_target_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_target_rest_flattened_error(transport: str = "rest"):
+def test_set_target_unary_rest_flattened_error(transport: str = "rest"):
     client = ForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1804,7 +1804,7 @@ def test_set_target_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_target(
+        client.set_target_unary(
             compute.SetTargetForwardingRuleRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_global_addresses.py
+++ b/tests/unit/gapic/compute_v1/test_global_addresses.py
@@ -419,7 +419,7 @@ def test_global_addresses_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteGlobalAddressRequest
 ):
     client = GlobalAddressesClient(
@@ -464,7 +464,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -492,7 +492,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteGlobalAddressRequest
 ):
     client = GlobalAddressesClient(
@@ -512,14 +512,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = GlobalAddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -543,7 +543,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", address="address_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -556,7 +556,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalAddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -564,7 +564,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteGlobalAddressRequest(),
             project="project_value",
             address="address_value",
@@ -713,7 +713,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertGlobalAddressRequest
 ):
     client = GlobalAddressesClient(
@@ -759,7 +759,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -787,7 +787,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertGlobalAddressRequest
 ):
     client = GlobalAddressesClient(
@@ -808,14 +808,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = GlobalAddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -842,7 +842,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             address_resource=compute.Address(address="address_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -855,7 +855,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalAddressesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -863,7 +863,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertGlobalAddressRequest(),
             project="project_value",
             address_resource=compute.Address(address="address_value"),

--- a/tests/unit/gapic/compute_v1/test_global_forwarding_rules.py
+++ b/tests/unit/gapic/compute_v1/test_global_forwarding_rules.py
@@ -440,7 +440,7 @@ def test_global_forwarding_rules_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -485,7 +485,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -513,7 +513,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -533,14 +533,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -566,7 +566,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", forwarding_rule="forwarding_rule_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -579,7 +579,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -587,7 +587,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteGlobalForwardingRuleRequest(),
             project="project_value",
             forwarding_rule="forwarding_rule_value",
@@ -758,7 +758,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -806,7 +806,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -834,7 +834,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -857,14 +857,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -893,7 +893,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -906,7 +906,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -914,7 +914,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertGlobalForwardingRuleRequest(),
             project="project_value",
             forwarding_rule_resource=compute.ForwardingRule(
@@ -1088,7 +1088,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1136,7 +1136,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1164,7 +1164,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1187,14 +1187,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1224,7 +1224,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1237,7 +1237,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1245,7 +1245,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchGlobalForwardingRuleRequest(),
             project="project_value",
             forwarding_rule="forwarding_rule_value",
@@ -1255,7 +1255,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1303,7 +1303,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1331,7 +1331,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1354,14 +1354,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1391,7 +1391,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1404,7 +1404,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1412,7 +1412,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsGlobalForwardingRuleRequest(),
             project="project_value",
             resource="resource_value",
@@ -1422,7 +1422,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_target_rest(
+def test_set_target_unary_rest(
     transport: str = "rest", request_type=compute.SetTargetGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1470,7 +1470,7 @@ def test_set_target_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_target(request)
+        response = client.set_target_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1498,7 +1498,7 @@ def test_set_target_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_target_rest_bad_request(
+def test_set_target_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetTargetGlobalForwardingRuleRequest
 ):
     client = GlobalForwardingRulesClient(
@@ -1521,14 +1521,14 @@ def test_set_target_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_target(request)
+        client.set_target_unary(request)
 
 
-def test_set_target_rest_from_dict():
-    test_set_target_rest(request_type=dict)
+def test_set_target_unary_rest_from_dict():
+    test_set_target_unary_rest(request_type=dict)
 
 
-def test_set_target_rest_flattened(transport: str = "rest"):
+def test_set_target_unary_rest_flattened(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1556,7 +1556,7 @@ def test_set_target_rest_flattened(transport: str = "rest"):
             target_reference_resource=compute.TargetReference(target="target_value"),
         )
         mock_args.update(sample_request)
-        client.set_target(**mock_args)
+        client.set_target_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1569,7 +1569,7 @@ def test_set_target_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_target_rest_flattened_error(transport: str = "rest"):
+def test_set_target_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalForwardingRulesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1577,7 +1577,7 @@ def test_set_target_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_target(
+        client.set_target_unary(
             compute.SetTargetGlobalForwardingRuleRequest(),
             project="project_value",
             forwarding_rule="forwarding_rule_value",

--- a/tests/unit/gapic/compute_v1/test_global_network_endpoint_groups.py
+++ b/tests/unit/gapic/compute_v1/test_global_network_endpoint_groups.py
@@ -446,7 +446,7 @@ def test_global_network_endpoint_groups_client_client_options_credentials_file(
         )
 
 
-def test_attach_network_endpoints_rest(
+def test_attach_network_endpoints_unary_rest(
     transport: str = "rest",
     request_type=compute.AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest,
 ):
@@ -499,7 +499,7 @@ def test_attach_network_endpoints_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.attach_network_endpoints(request)
+        response = client.attach_network_endpoints_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -527,7 +527,7 @@ def test_attach_network_endpoints_rest(
     assert response.zone == "zone_value"
 
 
-def test_attach_network_endpoints_rest_bad_request(
+def test_attach_network_endpoints_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest,
 ):
@@ -555,14 +555,14 @@ def test_attach_network_endpoints_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.attach_network_endpoints(request)
+        client.attach_network_endpoints_unary(request)
 
 
-def test_attach_network_endpoints_rest_from_dict():
-    test_attach_network_endpoints_rest(request_type=dict)
+def test_attach_network_endpoints_unary_rest_from_dict():
+    test_attach_network_endpoints_unary_rest(request_type=dict)
 
 
-def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
+def test_attach_network_endpoints_unary_rest_flattened(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -594,7 +594,7 @@ def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.attach_network_endpoints(**mock_args)
+        client.attach_network_endpoints_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -607,7 +607,7 @@ def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
+def test_attach_network_endpoints_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -615,7 +615,7 @@ def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.attach_network_endpoints(
+        client.attach_network_endpoints_unary(
             compute.AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest(),
             project="project_value",
             network_endpoint_group="network_endpoint_group_value",
@@ -627,7 +627,7 @@ def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteGlobalNetworkEndpointGroupRequest,
 ):
@@ -673,7 +673,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -701,7 +701,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteGlobalNetworkEndpointGroupRequest,
 ):
@@ -722,14 +722,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -756,7 +756,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             network_endpoint_group="network_endpoint_group_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -769,7 +769,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -777,14 +777,14 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteGlobalNetworkEndpointGroupRequest(),
             project="project_value",
             network_endpoint_group="network_endpoint_group_value",
         )
 
 
-def test_detach_network_endpoints_rest(
+def test_detach_network_endpoints_unary_rest(
     transport: str = "rest",
     request_type=compute.DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest,
 ):
@@ -837,7 +837,7 @@ def test_detach_network_endpoints_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.detach_network_endpoints(request)
+        response = client.detach_network_endpoints_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -865,7 +865,7 @@ def test_detach_network_endpoints_rest(
     assert response.zone == "zone_value"
 
 
-def test_detach_network_endpoints_rest_bad_request(
+def test_detach_network_endpoints_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest,
 ):
@@ -893,14 +893,14 @@ def test_detach_network_endpoints_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.detach_network_endpoints(request)
+        client.detach_network_endpoints_unary(request)
 
 
-def test_detach_network_endpoints_rest_from_dict():
-    test_detach_network_endpoints_rest(request_type=dict)
+def test_detach_network_endpoints_unary_rest_from_dict():
+    test_detach_network_endpoints_unary_rest(request_type=dict)
 
 
-def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
+def test_detach_network_endpoints_unary_rest_flattened(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -932,7 +932,7 @@ def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.detach_network_endpoints(**mock_args)
+        client.detach_network_endpoints_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -945,7 +945,7 @@ def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_detach_network_endpoints_rest_flattened_error(transport: str = "rest"):
+def test_detach_network_endpoints_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -953,7 +953,7 @@ def test_detach_network_endpoints_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.detach_network_endpoints(
+        client.detach_network_endpoints_unary(
             compute.DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest(),
             project="project_value",
             network_endpoint_group="network_endpoint_group_value",
@@ -1102,7 +1102,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest",
     request_type=compute.InsertGlobalNetworkEndpointGroupRequest,
 ):
@@ -1151,7 +1151,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1179,7 +1179,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.InsertGlobalNetworkEndpointGroupRequest,
 ):
@@ -1203,14 +1203,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1239,7 +1239,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1252,7 +1252,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1260,7 +1260,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertGlobalNetworkEndpointGroupRequest(),
             project="project_value",
             network_endpoint_group_resource=compute.NetworkEndpointGroup(

--- a/tests/unit/gapic/compute_v1/test_global_public_delegated_prefixes.py
+++ b/tests/unit/gapic/compute_v1/test_global_public_delegated_prefixes.py
@@ -452,7 +452,7 @@ def test_global_public_delegated_prefixes_client_client_options_credentials_file
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -498,7 +498,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -526,7 +526,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -547,14 +547,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -581,7 +581,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             public_delegated_prefix="public_delegated_prefix_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -594,7 +594,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -602,7 +602,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteGlobalPublicDelegatedPrefixeRequest(),
             project="project_value",
             public_delegated_prefix="public_delegated_prefix_value",
@@ -744,7 +744,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest",
     request_type=compute.InsertGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -793,7 +793,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -821,7 +821,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.InsertGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -845,14 +845,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -881,7 +881,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -894,7 +894,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -902,7 +902,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertGlobalPublicDelegatedPrefixeRequest(),
             project="project_value",
             public_delegated_prefix_resource=compute.PublicDelegatedPrefix(
@@ -1081,7 +1081,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest",
     request_type=compute.PatchGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -1130,7 +1130,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1158,7 +1158,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.PatchGlobalPublicDelegatedPrefixeRequest,
 ):
@@ -1182,14 +1182,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1219,7 +1219,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1232,7 +1232,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = GlobalPublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1240,7 +1240,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchGlobalPublicDelegatedPrefixeRequest(),
             project="project_value",
             public_delegated_prefix="public_delegated_prefix_value",

--- a/tests/unit/gapic/compute_v1/test_health_checks.py
+++ b/tests/unit/gapic/compute_v1/test_health_checks.py
@@ -583,7 +583,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -628,7 +628,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -656,7 +656,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -676,14 +676,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -707,7 +707,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", health_check="health_check_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -720,7 +720,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -728,7 +728,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteHealthCheckRequest(),
             project="project_value",
             health_check="health_check_value",
@@ -865,7 +865,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -911,7 +911,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -939,7 +939,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -960,14 +960,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -994,7 +994,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1007,7 +1007,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1015,7 +1015,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertHealthCheckRequest(),
             project="project_value",
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
@@ -1185,7 +1185,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -1231,7 +1231,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1259,7 +1259,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -1280,14 +1280,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1315,7 +1315,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1328,7 +1328,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1336,7 +1336,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchHealthCheckRequest(),
             project="project_value",
             health_check="health_check_value",
@@ -1344,7 +1344,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -1390,7 +1390,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1418,7 +1418,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateHealthCheckRequest
 ):
     client = HealthChecksClient(
@@ -1439,14 +1439,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1474,7 +1474,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1487,7 +1487,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = HealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1495,7 +1495,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateHealthCheckRequest(),
             project="project_value",
             health_check="health_check_value",

--- a/tests/unit/gapic/compute_v1/test_images.py
+++ b/tests/unit/gapic/compute_v1/test_images.py
@@ -394,7 +394,9 @@ def test_images_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(transport: str = "rest", request_type=compute.DeleteImageRequest):
+def test_delete_unary_rest(
+    transport: str = "rest", request_type=compute.DeleteImageRequest
+):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -437,7 +439,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteImageRe
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -465,7 +467,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteImageRe
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteImageRequest
 ):
     client = ImagesClient(
@@ -485,14 +487,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -516,7 +518,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", image="image_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -529,7 +531,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -537,12 +539,12 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteImageRequest(), project="project_value", image="image_value",
         )
 
 
-def test_deprecate_rest(
+def test_deprecate_unary_rest(
     transport: str = "rest", request_type=compute.DeprecateImageRequest
 ):
     client = ImagesClient(
@@ -590,7 +592,7 @@ def test_deprecate_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.deprecate(request)
+        response = client.deprecate_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -618,7 +620,7 @@ def test_deprecate_rest(
     assert response.zone == "zone_value"
 
 
-def test_deprecate_rest_bad_request(
+def test_deprecate_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeprecateImageRequest
 ):
     client = ImagesClient(
@@ -641,14 +643,14 @@ def test_deprecate_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.deprecate(request)
+        client.deprecate_unary(request)
 
 
-def test_deprecate_rest_from_dict():
-    test_deprecate_rest(request_type=dict)
+def test_deprecate_unary_rest_from_dict():
+    test_deprecate_unary_rest(request_type=dict)
 
 
-def test_deprecate_rest_flattened(transport: str = "rest"):
+def test_deprecate_unary_rest_flattened(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -678,7 +680,7 @@ def test_deprecate_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.deprecate(**mock_args)
+        client.deprecate_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -691,7 +693,7 @@ def test_deprecate_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_deprecate_rest_flattened_error(transport: str = "rest"):
+def test_deprecate_unary_rest_flattened_error(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -699,7 +701,7 @@ def test_deprecate_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.deprecate(
+        client.deprecate_unary(
             compute.DeprecateImageRequest(),
             project="project_value",
             image="image_value",
@@ -1119,7 +1121,9 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(transport: str = "rest", request_type=compute.InsertImageRequest):
+def test_insert_unary_rest(
+    transport: str = "rest", request_type=compute.InsertImageRequest
+):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1163,7 +1167,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertImageRe
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1191,7 +1195,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertImageRe
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertImageRequest
 ):
     client = ImagesClient(
@@ -1212,14 +1216,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1246,7 +1250,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             image_resource=compute.Image(archive_size_bytes=1922),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1259,7 +1263,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1267,7 +1271,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertImageRequest(),
             project="project_value",
             image_resource=compute.Image(archive_size_bytes=1922),
@@ -1427,7 +1431,9 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(transport: str = "rest", request_type=compute.PatchImageRequest):
+def test_patch_unary_rest(
+    transport: str = "rest", request_type=compute.PatchImageRequest
+):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1471,7 +1477,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchImageRequ
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1499,7 +1505,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchImageRequ
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchImageRequest
 ):
     client = ImagesClient(
@@ -1520,14 +1526,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1555,7 +1561,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             image_resource=compute.Image(archive_size_bytes=1922),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1568,7 +1574,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1576,7 +1582,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchImageRequest(),
             project="project_value",
             image="image_value",
@@ -1709,7 +1715,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsImageRequest
 ):
     client = ImagesClient(
@@ -1757,7 +1763,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1785,7 +1791,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsImageRequest
 ):
     client = ImagesClient(
@@ -1808,14 +1814,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1845,7 +1851,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1858,7 +1864,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = ImagesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1866,7 +1872,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsImageRequest(),
             project="project_value",
             resource="resource_value",

--- a/tests/unit/gapic/compute_v1/test_instance_group_managers.py
+++ b/tests/unit/gapic/compute_v1/test_instance_group_managers.py
@@ -440,7 +440,7 @@ def test_instance_group_managers_client_client_options_credentials_file(
         )
 
 
-def test_abandon_instances_rest(
+def test_abandon_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.AbandonInstancesInstanceGroupManagerRequest,
 ):
@@ -495,7 +495,7 @@ def test_abandon_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.abandon_instances(request)
+        response = client.abandon_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -523,7 +523,7 @@ def test_abandon_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_abandon_instances_rest_bad_request(
+def test_abandon_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.AbandonInstancesInstanceGroupManagerRequest,
 ):
@@ -553,14 +553,14 @@ def test_abandon_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.abandon_instances(request)
+        client.abandon_instances_unary(request)
 
 
-def test_abandon_instances_rest_from_dict():
-    test_abandon_instances_rest(request_type=dict)
+def test_abandon_instances_unary_rest_from_dict():
+    test_abandon_instances_unary_rest(request_type=dict)
 
 
-def test_abandon_instances_rest_flattened(transport: str = "rest"):
+def test_abandon_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -595,7 +595,7 @@ def test_abandon_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.abandon_instances(**mock_args)
+        client.abandon_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -608,7 +608,7 @@ def test_abandon_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_abandon_instances_rest_flattened_error(transport: str = "rest"):
+def test_abandon_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -616,7 +616,7 @@ def test_abandon_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.abandon_instances(
+        client.abandon_instances_unary(
             compute.AbandonInstancesInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -821,7 +821,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_apply_updates_to_instances_rest(
+def test_apply_updates_to_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.ApplyUpdatesToInstancesInstanceGroupManagerRequest,
 ):
@@ -874,7 +874,7 @@ def test_apply_updates_to_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.apply_updates_to_instances(request)
+        response = client.apply_updates_to_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -902,7 +902,7 @@ def test_apply_updates_to_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_apply_updates_to_instances_rest_bad_request(
+def test_apply_updates_to_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.ApplyUpdatesToInstancesInstanceGroupManagerRequest,
 ):
@@ -930,14 +930,14 @@ def test_apply_updates_to_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.apply_updates_to_instances(request)
+        client.apply_updates_to_instances_unary(request)
 
 
-def test_apply_updates_to_instances_rest_from_dict():
-    test_apply_updates_to_instances_rest(request_type=dict)
+def test_apply_updates_to_instances_unary_rest_from_dict():
+    test_apply_updates_to_instances_unary_rest(request_type=dict)
 
 
-def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
+def test_apply_updates_to_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -972,7 +972,7 @@ def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.apply_updates_to_instances(**mock_args)
+        client.apply_updates_to_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -985,7 +985,7 @@ def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"):
+def test_apply_updates_to_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -993,7 +993,7 @@ def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.apply_updates_to_instances(
+        client.apply_updates_to_instances_unary(
             compute.ApplyUpdatesToInstancesInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1004,7 +1004,7 @@ def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"
         )
 
 
-def test_create_instances_rest(
+def test_create_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.CreateInstancesInstanceGroupManagerRequest,
 ):
@@ -1059,7 +1059,7 @@ def test_create_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.create_instances(request)
+        response = client.create_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1087,7 +1087,7 @@ def test_create_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_create_instances_rest_bad_request(
+def test_create_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.CreateInstancesInstanceGroupManagerRequest,
 ):
@@ -1117,14 +1117,14 @@ def test_create_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.create_instances(request)
+        client.create_instances_unary(request)
 
 
-def test_create_instances_rest_from_dict():
-    test_create_instances_rest(request_type=dict)
+def test_create_instances_unary_rest_from_dict():
+    test_create_instances_unary_rest(request_type=dict)
 
 
-def test_create_instances_rest_flattened(transport: str = "rest"):
+def test_create_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1159,7 +1159,7 @@ def test_create_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.create_instances(**mock_args)
+        client.create_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1172,7 +1172,7 @@ def test_create_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_create_instances_rest_flattened_error(transport: str = "rest"):
+def test_create_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1180,7 +1180,7 @@ def test_create_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.create_instances(
+        client.create_instances_unary(
             compute.CreateInstancesInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1191,7 +1191,7 @@ def test_create_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -1240,7 +1240,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1268,7 +1268,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -1292,14 +1292,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1331,7 +1331,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             instance_group_manager="instance_group_manager_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1344,7 +1344,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1352,7 +1352,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1360,7 +1360,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_instances_rest(
+def test_delete_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteInstancesInstanceGroupManagerRequest,
 ):
@@ -1415,7 +1415,7 @@ def test_delete_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_instances(request)
+        response = client.delete_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1443,7 +1443,7 @@ def test_delete_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_instances_rest_bad_request(
+def test_delete_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteInstancesInstanceGroupManagerRequest,
 ):
@@ -1473,14 +1473,14 @@ def test_delete_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_instances(request)
+        client.delete_instances_unary(request)
 
 
-def test_delete_instances_rest_from_dict():
-    test_delete_instances_rest(request_type=dict)
+def test_delete_instances_unary_rest_from_dict():
+    test_delete_instances_unary_rest(request_type=dict)
 
 
-def test_delete_instances_rest_flattened(transport: str = "rest"):
+def test_delete_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1515,7 +1515,7 @@ def test_delete_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.delete_instances(**mock_args)
+        client.delete_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1528,7 +1528,7 @@ def test_delete_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_instances_rest_flattened_error(transport: str = "rest"):
+def test_delete_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1536,7 +1536,7 @@ def test_delete_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_instances(
+        client.delete_instances_unary(
             compute.DeleteInstancesInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1547,7 +1547,7 @@ def test_delete_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_per_instance_configs_rest(
+def test_delete_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.DeletePerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -1600,7 +1600,7 @@ def test_delete_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_per_instance_configs(request)
+        response = client.delete_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1628,7 +1628,7 @@ def test_delete_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_per_instance_configs_rest_bad_request(
+def test_delete_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeletePerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -1656,14 +1656,14 @@ def test_delete_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_per_instance_configs(request)
+        client.delete_per_instance_configs_unary(request)
 
 
-def test_delete_per_instance_configs_rest_from_dict():
-    test_delete_per_instance_configs_rest(request_type=dict)
+def test_delete_per_instance_configs_unary_rest_from_dict():
+    test_delete_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_delete_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1698,7 +1698,7 @@ def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.delete_per_instance_configs(**mock_args)
+        client.delete_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1711,7 +1711,9 @@ def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_delete_per_instance_configs_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1719,7 +1721,7 @@ def test_delete_per_instance_configs_rest_flattened_error(transport: str = "rest
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_per_instance_configs(
+        client.delete_per_instance_configs_unary(
             compute.DeletePerInstanceConfigsInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -1883,7 +1885,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -1935,7 +1937,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1963,7 +1965,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -1990,14 +1992,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2031,7 +2033,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2044,7 +2046,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2052,7 +2054,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -2815,7 +2817,7 @@ def test_list_per_instance_configs_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -2871,7 +2873,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2899,7 +2901,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -2930,14 +2932,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2976,7 +2978,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2989,7 +2991,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2997,7 +2999,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3012,7 +3014,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_patch_per_instance_configs_rest(
+def test_patch_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.PatchPerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -3069,7 +3071,7 @@ def test_patch_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch_per_instance_configs(request)
+        response = client.patch_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3097,7 +3099,7 @@ def test_patch_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_per_instance_configs_rest_bad_request(
+def test_patch_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.PatchPerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -3129,14 +3131,14 @@ def test_patch_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch_per_instance_configs(request)
+        client.patch_per_instance_configs_unary(request)
 
 
-def test_patch_per_instance_configs_rest_from_dict():
-    test_patch_per_instance_configs_rest(request_type=dict)
+def test_patch_per_instance_configs_unary_rest_from_dict():
+    test_patch_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_patch_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3173,7 +3175,7 @@ def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch_per_instance_configs(**mock_args)
+        client.patch_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3186,7 +3188,7 @@ def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_patch_per_instance_configs_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3194,7 +3196,7 @@ def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch_per_instance_configs(
+        client.patch_per_instance_configs_unary(
             compute.PatchPerInstanceConfigsInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3207,7 +3209,7 @@ def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"
         )
 
 
-def test_recreate_instances_rest(
+def test_recreate_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.RecreateInstancesInstanceGroupManagerRequest,
 ):
@@ -3262,7 +3264,7 @@ def test_recreate_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.recreate_instances(request)
+        response = client.recreate_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3290,7 +3292,7 @@ def test_recreate_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_recreate_instances_rest_bad_request(
+def test_recreate_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.RecreateInstancesInstanceGroupManagerRequest,
 ):
@@ -3320,14 +3322,14 @@ def test_recreate_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.recreate_instances(request)
+        client.recreate_instances_unary(request)
 
 
-def test_recreate_instances_rest_from_dict():
-    test_recreate_instances_rest(request_type=dict)
+def test_recreate_instances_unary_rest_from_dict():
+    test_recreate_instances_unary_rest(request_type=dict)
 
 
-def test_recreate_instances_rest_flattened(transport: str = "rest"):
+def test_recreate_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3362,7 +3364,7 @@ def test_recreate_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.recreate_instances(**mock_args)
+        client.recreate_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3375,7 +3377,7 @@ def test_recreate_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
+def test_recreate_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3383,7 +3385,7 @@ def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.recreate_instances(
+        client.recreate_instances_unary(
             compute.RecreateInstancesInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3394,7 +3396,7 @@ def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_resize_rest(
+def test_resize_unary_rest(
     transport: str = "rest", request_type=compute.ResizeInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -3443,7 +3445,7 @@ def test_resize_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.resize(request)
+        response = client.resize_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3471,7 +3473,7 @@ def test_resize_rest(
     assert response.zone == "zone_value"
 
 
-def test_resize_rest_bad_request(
+def test_resize_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ResizeInstanceGroupManagerRequest
 ):
     client = InstanceGroupManagersClient(
@@ -3495,14 +3497,14 @@ def test_resize_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.resize(request)
+        client.resize_unary(request)
 
 
-def test_resize_rest_from_dict():
-    test_resize_rest(request_type=dict)
+def test_resize_unary_rest_from_dict():
+    test_resize_unary_rest(request_type=dict)
 
 
-def test_resize_rest_flattened(transport: str = "rest"):
+def test_resize_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3535,7 +3537,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
             size=443,
         )
         mock_args.update(sample_request)
-        client.resize(**mock_args)
+        client.resize_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3548,7 +3550,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_resize_rest_flattened_error(transport: str = "rest"):
+def test_resize_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3556,7 +3558,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.resize(
+        client.resize_unary(
             compute.ResizeInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3565,7 +3567,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_instance_template_rest(
+def test_set_instance_template_unary_rest(
     transport: str = "rest",
     request_type=compute.SetInstanceTemplateInstanceGroupManagerRequest,
 ):
@@ -3620,7 +3622,7 @@ def test_set_instance_template_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_instance_template(request)
+        response = client.set_instance_template_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3648,7 +3650,7 @@ def test_set_instance_template_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_instance_template_rest_bad_request(
+def test_set_instance_template_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetInstanceTemplateInstanceGroupManagerRequest,
 ):
@@ -3678,14 +3680,14 @@ def test_set_instance_template_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_instance_template(request)
+        client.set_instance_template_unary(request)
 
 
-def test_set_instance_template_rest_from_dict():
-    test_set_instance_template_rest(request_type=dict)
+def test_set_instance_template_unary_rest_from_dict():
+    test_set_instance_template_unary_rest(request_type=dict)
 
 
-def test_set_instance_template_rest_flattened(transport: str = "rest"):
+def test_set_instance_template_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3720,7 +3722,7 @@ def test_set_instance_template_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_instance_template(**mock_args)
+        client.set_instance_template_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3733,7 +3735,7 @@ def test_set_instance_template_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
+def test_set_instance_template_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3741,7 +3743,7 @@ def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_instance_template(
+        client.set_instance_template_unary(
             compute.SetInstanceTemplateInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3752,7 +3754,7 @@ def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_target_pools_rest(
+def test_set_target_pools_unary_rest(
     transport: str = "rest",
     request_type=compute.SetTargetPoolsInstanceGroupManagerRequest,
 ):
@@ -3807,7 +3809,7 @@ def test_set_target_pools_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_target_pools(request)
+        response = client.set_target_pools_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3835,7 +3837,7 @@ def test_set_target_pools_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_target_pools_rest_bad_request(
+def test_set_target_pools_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetTargetPoolsInstanceGroupManagerRequest,
 ):
@@ -3865,14 +3867,14 @@ def test_set_target_pools_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_target_pools(request)
+        client.set_target_pools_unary(request)
 
 
-def test_set_target_pools_rest_from_dict():
-    test_set_target_pools_rest(request_type=dict)
+def test_set_target_pools_unary_rest_from_dict():
+    test_set_target_pools_unary_rest(request_type=dict)
 
 
-def test_set_target_pools_rest_flattened(transport: str = "rest"):
+def test_set_target_pools_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3907,7 +3909,7 @@ def test_set_target_pools_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_target_pools(**mock_args)
+        client.set_target_pools_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3920,7 +3922,7 @@ def test_set_target_pools_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
+def test_set_target_pools_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3928,7 +3930,7 @@ def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_target_pools(
+        client.set_target_pools_unary(
             compute.SetTargetPoolsInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",
@@ -3939,7 +3941,7 @@ def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_per_instance_configs_rest(
+def test_update_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.UpdatePerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -3996,7 +3998,7 @@ def test_update_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_per_instance_configs(request)
+        response = client.update_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4024,7 +4026,7 @@ def test_update_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_per_instance_configs_rest_bad_request(
+def test_update_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.UpdatePerInstanceConfigsInstanceGroupManagerRequest,
 ):
@@ -4056,14 +4058,14 @@ def test_update_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_per_instance_configs(request)
+        client.update_per_instance_configs_unary(request)
 
 
-def test_update_per_instance_configs_rest_from_dict():
-    test_update_per_instance_configs_rest(request_type=dict)
+def test_update_per_instance_configs_unary_rest_from_dict():
+    test_update_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_update_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4100,7 +4102,7 @@ def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update_per_instance_configs(**mock_args)
+        client.update_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4113,7 +4115,9 @@ def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_update_per_instance_configs_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = InstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4121,7 +4125,7 @@ def test_update_per_instance_configs_rest_flattened_error(transport: str = "rest
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_per_instance_configs(
+        client.update_per_instance_configs_unary(
             compute.UpdatePerInstanceConfigsInstanceGroupManagerRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_instance_groups.py
+++ b/tests/unit/gapic/compute_v1/test_instance_groups.py
@@ -409,7 +409,7 @@ def test_instance_groups_client_client_options_credentials_file(
         )
 
 
-def test_add_instances_rest(
+def test_add_instances_unary_rest(
     transport: str = "rest", request_type=compute.AddInstancesInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -463,7 +463,7 @@ def test_add_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_instances(request)
+        response = client.add_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -491,7 +491,7 @@ def test_add_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_instances_rest_bad_request(
+def test_add_instances_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddInstancesInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -520,14 +520,14 @@ def test_add_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_instances(request)
+        client.add_instances_unary(request)
 
 
-def test_add_instances_rest_from_dict():
-    test_add_instances_rest(request_type=dict)
+def test_add_instances_unary_rest_from_dict():
+    test_add_instances_unary_rest(request_type=dict)
 
 
-def test_add_instances_rest_flattened(transport: str = "rest"):
+def test_add_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -562,7 +562,7 @@ def test_add_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_instances(**mock_args)
+        client.add_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -575,7 +575,7 @@ def test_add_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_instances_rest_flattened_error(transport: str = "rest"):
+def test_add_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -583,7 +583,7 @@ def test_add_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_instances(
+        client.add_instances_unary(
             compute.AddInstancesInstanceGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -776,7 +776,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -825,7 +825,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -853,7 +853,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -877,14 +877,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -916,7 +916,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             instance_group="instance_group_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -929,7 +929,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -937,7 +937,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInstanceGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1094,7 +1094,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1142,7 +1142,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1170,7 +1170,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1193,14 +1193,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1230,7 +1230,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1243,7 +1243,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1251,7 +1251,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInstanceGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1638,7 +1638,7 @@ def test_list_instances_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_remove_instances_rest(
+def test_remove_instances_unary_rest(
     transport: str = "rest", request_type=compute.RemoveInstancesInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1692,7 +1692,7 @@ def test_remove_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_instances(request)
+        response = client.remove_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1720,7 +1720,7 @@ def test_remove_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_instances_rest_bad_request(
+def test_remove_instances_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveInstancesInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1749,14 +1749,14 @@ def test_remove_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_instances(request)
+        client.remove_instances_unary(request)
 
 
-def test_remove_instances_rest_from_dict():
-    test_remove_instances_rest(request_type=dict)
+def test_remove_instances_unary_rest_from_dict():
+    test_remove_instances_unary_rest(request_type=dict)
 
 
-def test_remove_instances_rest_flattened(transport: str = "rest"):
+def test_remove_instances_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1791,7 +1791,7 @@ def test_remove_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_instances(**mock_args)
+        client.remove_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1804,7 +1804,7 @@ def test_remove_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_instances_rest_flattened_error(transport: str = "rest"):
+def test_remove_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1812,7 +1812,7 @@ def test_remove_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_instances(
+        client.remove_instances_unary(
             compute.RemoveInstancesInstanceGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1823,7 +1823,7 @@ def test_remove_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_named_ports_rest(
+def test_set_named_ports_unary_rest(
     transport: str = "rest", request_type=compute.SetNamedPortsInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1875,7 +1875,7 @@ def test_set_named_ports_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_named_ports(request)
+        response = client.set_named_ports_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1903,7 +1903,7 @@ def test_set_named_ports_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_named_ports_rest_bad_request(
+def test_set_named_ports_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetNamedPortsInstanceGroupRequest
 ):
     client = InstanceGroupsClient(
@@ -1930,14 +1930,14 @@ def test_set_named_ports_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_named_ports(request)
+        client.set_named_ports_unary(request)
 
 
-def test_set_named_ports_rest_from_dict():
-    test_set_named_ports_rest(request_type=dict)
+def test_set_named_ports_unary_rest_from_dict():
+    test_set_named_ports_unary_rest(request_type=dict)
 
 
-def test_set_named_ports_rest_flattened(transport: str = "rest"):
+def test_set_named_ports_unary_rest_flattened(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1972,7 +1972,7 @@ def test_set_named_ports_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_named_ports(**mock_args)
+        client.set_named_ports_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1985,7 +1985,7 @@ def test_set_named_ports_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_named_ports_rest_flattened_error(transport: str = "rest"):
+def test_set_named_ports_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1993,7 +1993,7 @@ def test_set_named_ports_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_named_ports(
+        client.set_named_ports_unary(
             compute.SetNamedPortsInstanceGroupRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_instance_templates.py
+++ b/tests/unit/gapic/compute_v1/test_instance_templates.py
@@ -420,7 +420,7 @@ def test_instance_templates_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInstanceTemplateRequest
 ):
     client = InstanceTemplatesClient(
@@ -465,7 +465,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -493,7 +493,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInstanceTemplateRequest
 ):
     client = InstanceTemplatesClient(
@@ -513,14 +513,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InstanceTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -546,7 +546,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", instance_template="instance_template_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -559,7 +559,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -567,7 +567,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInstanceTemplateRequest(),
             project="project_value",
             instance_template="instance_template_value",
@@ -808,7 +808,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInstanceTemplateRequest
 ):
     client = InstanceTemplatesClient(
@@ -856,7 +856,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -884,7 +884,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInstanceTemplateRequest
 ):
     client = InstanceTemplatesClient(
@@ -907,14 +907,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InstanceTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -943,7 +943,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -956,7 +956,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InstanceTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -964,7 +964,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInstanceTemplateRequest(),
             project="project_value",
             instance_template_resource=compute.InstanceTemplate(

--- a/tests/unit/gapic/compute_v1/test_instances.py
+++ b/tests/unit/gapic/compute_v1/test_instances.py
@@ -397,7 +397,7 @@ def test_instances_client_client_options_credentials_file(
         )
 
 
-def test_add_access_config_rest(
+def test_add_access_config_unary_rest(
     transport: str = "rest", request_type=compute.AddAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -445,7 +445,7 @@ def test_add_access_config_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_access_config(request)
+        response = client.add_access_config_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -473,7 +473,7 @@ def test_add_access_config_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_access_config_rest_bad_request(
+def test_add_access_config_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -496,14 +496,14 @@ def test_add_access_config_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_access_config(request)
+        client.add_access_config_unary(request)
 
 
-def test_add_access_config_rest_from_dict():
-    test_add_access_config_rest(request_type=dict)
+def test_add_access_config_unary_rest_from_dict():
+    test_add_access_config_unary_rest(request_type=dict)
 
 
-def test_add_access_config_rest_flattened(transport: str = "rest"):
+def test_add_access_config_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -539,7 +539,7 @@ def test_add_access_config_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_access_config(**mock_args)
+        client.add_access_config_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -552,7 +552,7 @@ def test_add_access_config_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_access_config_rest_flattened_error(transport: str = "rest"):
+def test_add_access_config_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -560,7 +560,7 @@ def test_add_access_config_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_access_config(
+        client.add_access_config_unary(
             compute.AddAccessConfigInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -572,7 +572,7 @@ def test_add_access_config_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_add_resource_policies_rest(
+def test_add_resource_policies_unary_rest(
     transport: str = "rest", request_type=compute.AddResourcePoliciesInstanceRequest
 ):
     client = InstancesClient(
@@ -622,7 +622,7 @@ def test_add_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_resource_policies(request)
+        response = client.add_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -650,7 +650,7 @@ def test_add_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_resource_policies_rest_bad_request(
+def test_add_resource_policies_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddResourcePoliciesInstanceRequest
 ):
     client = InstancesClient(
@@ -675,14 +675,14 @@ def test_add_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_resource_policies(request)
+        client.add_resource_policies_unary(request)
 
 
-def test_add_resource_policies_rest_from_dict():
-    test_add_resource_policies_rest(request_type=dict)
+def test_add_resource_policies_unary_rest_from_dict():
+    test_add_resource_policies_unary_rest(request_type=dict)
 
 
-def test_add_resource_policies_rest_flattened(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -717,7 +717,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_resource_policies(**mock_args)
+        client.add_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -730,7 +730,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -738,7 +738,7 @@ def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_resource_policies(
+        client.add_resource_policies_unary(
             compute.AddResourcePoliciesInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -926,7 +926,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_attach_disk_rest(
+def test_attach_disk_unary_rest(
     transport: str = "rest", request_type=compute.AttachDiskInstanceRequest
 ):
     client = InstancesClient(
@@ -972,7 +972,7 @@ def test_attach_disk_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.attach_disk(request)
+        response = client.attach_disk_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1000,7 +1000,7 @@ def test_attach_disk_rest(
     assert response.zone == "zone_value"
 
 
-def test_attach_disk_rest_bad_request(
+def test_attach_disk_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AttachDiskInstanceRequest
 ):
     client = InstancesClient(
@@ -1021,14 +1021,14 @@ def test_attach_disk_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.attach_disk(request)
+        client.attach_disk_unary(request)
 
 
-def test_attach_disk_rest_from_dict():
-    test_attach_disk_rest(request_type=dict)
+def test_attach_disk_unary_rest_from_dict():
+    test_attach_disk_unary_rest(request_type=dict)
 
 
-def test_attach_disk_rest_flattened(transport: str = "rest"):
+def test_attach_disk_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1061,7 +1061,7 @@ def test_attach_disk_rest_flattened(transport: str = "rest"):
             attached_disk_resource=compute.AttachedDisk(auto_delete=True),
         )
         mock_args.update(sample_request)
-        client.attach_disk(**mock_args)
+        client.attach_disk_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1074,7 +1074,7 @@ def test_attach_disk_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_attach_disk_rest_flattened_error(transport: str = "rest"):
+def test_attach_disk_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1082,7 +1082,7 @@ def test_attach_disk_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.attach_disk(
+        client.attach_disk_unary(
             compute.AttachDiskInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -1091,7 +1091,7 @@ def test_attach_disk_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_bulk_insert_rest(
+def test_bulk_insert_unary_rest(
     transport: str = "rest", request_type=compute.BulkInsertInstanceRequest
 ):
     client = InstancesClient(
@@ -1139,7 +1139,7 @@ def test_bulk_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.bulk_insert(request)
+        response = client.bulk_insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1167,7 +1167,7 @@ def test_bulk_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_bulk_insert_rest_bad_request(
+def test_bulk_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.BulkInsertInstanceRequest
 ):
     client = InstancesClient(
@@ -1190,14 +1190,14 @@ def test_bulk_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.bulk_insert(request)
+        client.bulk_insert_unary(request)
 
 
-def test_bulk_insert_rest_from_dict():
-    test_bulk_insert_rest(request_type=dict)
+def test_bulk_insert_unary_rest_from_dict():
+    test_bulk_insert_unary_rest(request_type=dict)
 
 
-def test_bulk_insert_rest_flattened(transport: str = "rest"):
+def test_bulk_insert_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1227,7 +1227,7 @@ def test_bulk_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.bulk_insert(**mock_args)
+        client.bulk_insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1240,7 +1240,7 @@ def test_bulk_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_bulk_insert_rest_flattened_error(transport: str = "rest"):
+def test_bulk_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1248,7 +1248,7 @@ def test_bulk_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.bulk_insert(
+        client.bulk_insert_unary(
             compute.BulkInsertInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -1258,7 +1258,7 @@ def test_bulk_insert_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInstanceRequest
 ):
     client = InstancesClient(
@@ -1303,7 +1303,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1331,7 +1331,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInstanceRequest
 ):
     client = InstancesClient(
@@ -1351,14 +1351,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1388,7 +1388,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", instance="instance_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1401,7 +1401,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1409,7 +1409,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -1417,7 +1417,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_access_config_rest(
+def test_delete_access_config_unary_rest(
     transport: str = "rest", request_type=compute.DeleteAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -1462,7 +1462,7 @@ def test_delete_access_config_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_access_config(request)
+        response = client.delete_access_config_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1490,7 +1490,7 @@ def test_delete_access_config_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_access_config_rest_bad_request(
+def test_delete_access_config_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -1510,14 +1510,14 @@ def test_delete_access_config_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_access_config(request)
+        client.delete_access_config_unary(request)
 
 
-def test_delete_access_config_rest_from_dict():
-    test_delete_access_config_rest(request_type=dict)
+def test_delete_access_config_unary_rest_from_dict():
+    test_delete_access_config_unary_rest(request_type=dict)
 
 
-def test_delete_access_config_rest_flattened(transport: str = "rest"):
+def test_delete_access_config_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1551,7 +1551,7 @@ def test_delete_access_config_rest_flattened(transport: str = "rest"):
             network_interface="network_interface_value",
         )
         mock_args.update(sample_request)
-        client.delete_access_config(**mock_args)
+        client.delete_access_config_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1564,7 +1564,7 @@ def test_delete_access_config_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_access_config_rest_flattened_error(transport: str = "rest"):
+def test_delete_access_config_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1572,7 +1572,7 @@ def test_delete_access_config_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_access_config(
+        client.delete_access_config_unary(
             compute.DeleteAccessConfigInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -1582,7 +1582,7 @@ def test_delete_access_config_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_detach_disk_rest(
+def test_detach_disk_unary_rest(
     transport: str = "rest", request_type=compute.DetachDiskInstanceRequest
 ):
     client = InstancesClient(
@@ -1627,7 +1627,7 @@ def test_detach_disk_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.detach_disk(request)
+        response = client.detach_disk_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1655,7 +1655,7 @@ def test_detach_disk_rest(
     assert response.zone == "zone_value"
 
 
-def test_detach_disk_rest_bad_request(
+def test_detach_disk_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DetachDiskInstanceRequest
 ):
     client = InstancesClient(
@@ -1675,14 +1675,14 @@ def test_detach_disk_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.detach_disk(request)
+        client.detach_disk_unary(request)
 
 
-def test_detach_disk_rest_from_dict():
-    test_detach_disk_rest(request_type=dict)
+def test_detach_disk_unary_rest_from_dict():
+    test_detach_disk_unary_rest(request_type=dict)
 
 
-def test_detach_disk_rest_flattened(transport: str = "rest"):
+def test_detach_disk_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1715,7 +1715,7 @@ def test_detach_disk_rest_flattened(transport: str = "rest"):
             device_name="device_name_value",
         )
         mock_args.update(sample_request)
-        client.detach_disk(**mock_args)
+        client.detach_disk_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1728,7 +1728,7 @@ def test_detach_disk_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_detach_disk_rest_flattened_error(transport: str = "rest"):
+def test_detach_disk_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1736,7 +1736,7 @@ def test_detach_disk_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.detach_disk(
+        client.detach_disk_unary(
             compute.DetachDiskInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -2628,7 +2628,7 @@ def test_get_shielded_instance_identity_rest_flattened_error(transport: str = "r
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInstanceRequest
 ):
     client = InstancesClient(
@@ -2678,7 +2678,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2706,7 +2706,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInstanceRequest
 ):
     client = InstancesClient(
@@ -2731,14 +2731,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2770,7 +2770,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2783,7 +2783,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2791,7 +2791,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -3128,7 +3128,7 @@ def test_list_referrers_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_remove_resource_policies_rest(
+def test_remove_resource_policies_unary_rest(
     transport: str = "rest", request_type=compute.RemoveResourcePoliciesInstanceRequest
 ):
     client = InstancesClient(
@@ -3178,7 +3178,7 @@ def test_remove_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_resource_policies(request)
+        response = client.remove_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3206,7 +3206,7 @@ def test_remove_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_resource_policies_rest_bad_request(
+def test_remove_resource_policies_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveResourcePoliciesInstanceRequest
 ):
     client = InstancesClient(
@@ -3231,14 +3231,14 @@ def test_remove_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_resource_policies(request)
+        client.remove_resource_policies_unary(request)
 
 
-def test_remove_resource_policies_rest_from_dict():
-    test_remove_resource_policies_rest(request_type=dict)
+def test_remove_resource_policies_unary_rest_from_dict():
+    test_remove_resource_policies_unary_rest(request_type=dict)
 
 
-def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3273,7 +3273,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_resource_policies(**mock_args)
+        client.remove_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3286,7 +3286,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3294,7 +3294,7 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_resource_policies(
+        client.remove_resource_policies_unary(
             compute.RemoveResourcePoliciesInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -3305,7 +3305,9 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_reset_rest(transport: str = "rest", request_type=compute.ResetInstanceRequest):
+def test_reset_unary_rest(
+    transport: str = "rest", request_type=compute.ResetInstanceRequest
+):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3348,7 +3350,7 @@ def test_reset_rest(transport: str = "rest", request_type=compute.ResetInstanceR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.reset(request)
+        response = client.reset_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3376,7 +3378,7 @@ def test_reset_rest(transport: str = "rest", request_type=compute.ResetInstanceR
     assert response.zone == "zone_value"
 
 
-def test_reset_rest_bad_request(
+def test_reset_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ResetInstanceRequest
 ):
     client = InstancesClient(
@@ -3396,14 +3398,14 @@ def test_reset_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.reset(request)
+        client.reset_unary(request)
 
 
-def test_reset_rest_from_dict():
-    test_reset_rest(request_type=dict)
+def test_reset_unary_rest_from_dict():
+    test_reset_unary_rest(request_type=dict)
 
 
-def test_reset_rest_flattened(transport: str = "rest"):
+def test_reset_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3433,7 +3435,7 @@ def test_reset_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", instance="instance_value",
         )
         mock_args.update(sample_request)
-        client.reset(**mock_args)
+        client.reset_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3446,7 +3448,7 @@ def test_reset_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_reset_rest_flattened_error(transport: str = "rest"):
+def test_reset_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3454,7 +3456,7 @@ def test_reset_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.reset(
+        client.reset_unary(
             compute.ResetInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -3580,7 +3582,7 @@ def test_send_diagnostic_interrupt_rest_flattened_error(transport: str = "rest")
         )
 
 
-def test_set_deletion_protection_rest(
+def test_set_deletion_protection_unary_rest(
     transport: str = "rest", request_type=compute.SetDeletionProtectionInstanceRequest
 ):
     client = InstancesClient(
@@ -3625,7 +3627,7 @@ def test_set_deletion_protection_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_deletion_protection(request)
+        response = client.set_deletion_protection_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3653,7 +3655,7 @@ def test_set_deletion_protection_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_deletion_protection_rest_bad_request(
+def test_set_deletion_protection_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetDeletionProtectionInstanceRequest
 ):
     client = InstancesClient(
@@ -3673,14 +3675,14 @@ def test_set_deletion_protection_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_deletion_protection(request)
+        client.set_deletion_protection_unary(request)
 
 
-def test_set_deletion_protection_rest_from_dict():
-    test_set_deletion_protection_rest(request_type=dict)
+def test_set_deletion_protection_unary_rest_from_dict():
+    test_set_deletion_protection_unary_rest(request_type=dict)
 
 
-def test_set_deletion_protection_rest_flattened(transport: str = "rest"):
+def test_set_deletion_protection_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3710,7 +3712,7 @@ def test_set_deletion_protection_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", resource="resource_value",
         )
         mock_args.update(sample_request)
-        client.set_deletion_protection(**mock_args)
+        client.set_deletion_protection_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3723,7 +3725,7 @@ def test_set_deletion_protection_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_deletion_protection_rest_flattened_error(transport: str = "rest"):
+def test_set_deletion_protection_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3731,7 +3733,7 @@ def test_set_deletion_protection_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_deletion_protection(
+        client.set_deletion_protection_unary(
             compute.SetDeletionProtectionInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -3739,7 +3741,7 @@ def test_set_deletion_protection_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_disk_auto_delete_rest(
+def test_set_disk_auto_delete_unary_rest(
     transport: str = "rest", request_type=compute.SetDiskAutoDeleteInstanceRequest
 ):
     client = InstancesClient(
@@ -3784,7 +3786,7 @@ def test_set_disk_auto_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_disk_auto_delete(request)
+        response = client.set_disk_auto_delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3812,7 +3814,7 @@ def test_set_disk_auto_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_disk_auto_delete_rest_bad_request(
+def test_set_disk_auto_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetDiskAutoDeleteInstanceRequest
 ):
     client = InstancesClient(
@@ -3832,14 +3834,14 @@ def test_set_disk_auto_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_disk_auto_delete(request)
+        client.set_disk_auto_delete_unary(request)
 
 
-def test_set_disk_auto_delete_rest_from_dict():
-    test_set_disk_auto_delete_rest(request_type=dict)
+def test_set_disk_auto_delete_unary_rest_from_dict():
+    test_set_disk_auto_delete_unary_rest(request_type=dict)
 
 
-def test_set_disk_auto_delete_rest_flattened(transport: str = "rest"):
+def test_set_disk_auto_delete_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3873,7 +3875,7 @@ def test_set_disk_auto_delete_rest_flattened(transport: str = "rest"):
             device_name="device_name_value",
         )
         mock_args.update(sample_request)
-        client.set_disk_auto_delete(**mock_args)
+        client.set_disk_auto_delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3886,7 +3888,7 @@ def test_set_disk_auto_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_disk_auto_delete_rest_flattened_error(transport: str = "rest"):
+def test_set_disk_auto_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3894,7 +3896,7 @@ def test_set_disk_auto_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_disk_auto_delete(
+        client.set_disk_auto_delete_unary(
             compute.SetDiskAutoDeleteInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4035,7 +4037,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsInstanceRequest
 ):
     client = InstancesClient(
@@ -4083,7 +4085,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4111,7 +4113,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsInstanceRequest
 ):
     client = InstancesClient(
@@ -4134,14 +4136,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4176,7 +4178,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4189,7 +4191,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4197,7 +4199,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4208,7 +4210,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_machine_resources_rest(
+def test_set_machine_resources_unary_rest(
     transport: str = "rest", request_type=compute.SetMachineResourcesInstanceRequest
 ):
     client = InstancesClient(
@@ -4258,7 +4260,7 @@ def test_set_machine_resources_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_machine_resources(request)
+        response = client.set_machine_resources_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4286,7 +4288,7 @@ def test_set_machine_resources_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_machine_resources_rest_bad_request(
+def test_set_machine_resources_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetMachineResourcesInstanceRequest
 ):
     client = InstancesClient(
@@ -4311,14 +4313,14 @@ def test_set_machine_resources_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_machine_resources(request)
+        client.set_machine_resources_unary(request)
 
 
-def test_set_machine_resources_rest_from_dict():
-    test_set_machine_resources_rest(request_type=dict)
+def test_set_machine_resources_unary_rest_from_dict():
+    test_set_machine_resources_unary_rest(request_type=dict)
 
 
-def test_set_machine_resources_rest_flattened(transport: str = "rest"):
+def test_set_machine_resources_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4353,7 +4355,7 @@ def test_set_machine_resources_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_machine_resources(**mock_args)
+        client.set_machine_resources_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4366,7 +4368,7 @@ def test_set_machine_resources_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_machine_resources_rest_flattened_error(transport: str = "rest"):
+def test_set_machine_resources_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4374,7 +4376,7 @@ def test_set_machine_resources_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_machine_resources(
+        client.set_machine_resources_unary(
             compute.SetMachineResourcesInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4385,7 +4387,7 @@ def test_set_machine_resources_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_machine_type_rest(
+def test_set_machine_type_unary_rest(
     transport: str = "rest", request_type=compute.SetMachineTypeInstanceRequest
 ):
     client = InstancesClient(
@@ -4433,7 +4435,7 @@ def test_set_machine_type_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_machine_type(request)
+        response = client.set_machine_type_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4461,7 +4463,7 @@ def test_set_machine_type_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_machine_type_rest_bad_request(
+def test_set_machine_type_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetMachineTypeInstanceRequest
 ):
     client = InstancesClient(
@@ -4484,14 +4486,14 @@ def test_set_machine_type_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_machine_type(request)
+        client.set_machine_type_unary(request)
 
 
-def test_set_machine_type_rest_from_dict():
-    test_set_machine_type_rest(request_type=dict)
+def test_set_machine_type_unary_rest_from_dict():
+    test_set_machine_type_unary_rest(request_type=dict)
 
 
-def test_set_machine_type_rest_flattened(transport: str = "rest"):
+def test_set_machine_type_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4526,7 +4528,7 @@ def test_set_machine_type_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_machine_type(**mock_args)
+        client.set_machine_type_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4539,7 +4541,7 @@ def test_set_machine_type_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_machine_type_rest_flattened_error(transport: str = "rest"):
+def test_set_machine_type_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4547,7 +4549,7 @@ def test_set_machine_type_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_machine_type(
+        client.set_machine_type_unary(
             compute.SetMachineTypeInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4558,7 +4560,7 @@ def test_set_machine_type_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_metadata_rest(
+def test_set_metadata_unary_rest(
     transport: str = "rest", request_type=compute.SetMetadataInstanceRequest
 ):
     client = InstancesClient(
@@ -4606,7 +4608,7 @@ def test_set_metadata_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_metadata(request)
+        response = client.set_metadata_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4634,7 +4636,7 @@ def test_set_metadata_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_metadata_rest_bad_request(
+def test_set_metadata_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetMetadataInstanceRequest
 ):
     client = InstancesClient(
@@ -4657,14 +4659,14 @@ def test_set_metadata_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_metadata(request)
+        client.set_metadata_unary(request)
 
 
-def test_set_metadata_rest_from_dict():
-    test_set_metadata_rest(request_type=dict)
+def test_set_metadata_unary_rest_from_dict():
+    test_set_metadata_unary_rest(request_type=dict)
 
 
-def test_set_metadata_rest_flattened(transport: str = "rest"):
+def test_set_metadata_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4697,7 +4699,7 @@ def test_set_metadata_rest_flattened(transport: str = "rest"):
             metadata_resource=compute.Metadata(fingerprint="fingerprint_value"),
         )
         mock_args.update(sample_request)
-        client.set_metadata(**mock_args)
+        client.set_metadata_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4710,7 +4712,7 @@ def test_set_metadata_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_metadata_rest_flattened_error(transport: str = "rest"):
+def test_set_metadata_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4718,7 +4720,7 @@ def test_set_metadata_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_metadata(
+        client.set_metadata_unary(
             compute.SetMetadataInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4727,7 +4729,7 @@ def test_set_metadata_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_min_cpu_platform_rest(
+def test_set_min_cpu_platform_unary_rest(
     transport: str = "rest", request_type=compute.SetMinCpuPlatformInstanceRequest
 ):
     client = InstancesClient(
@@ -4777,7 +4779,7 @@ def test_set_min_cpu_platform_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_min_cpu_platform(request)
+        response = client.set_min_cpu_platform_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4805,7 +4807,7 @@ def test_set_min_cpu_platform_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_min_cpu_platform_rest_bad_request(
+def test_set_min_cpu_platform_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetMinCpuPlatformInstanceRequest
 ):
     client = InstancesClient(
@@ -4830,14 +4832,14 @@ def test_set_min_cpu_platform_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_min_cpu_platform(request)
+        client.set_min_cpu_platform_unary(request)
 
 
-def test_set_min_cpu_platform_rest_from_dict():
-    test_set_min_cpu_platform_rest(request_type=dict)
+def test_set_min_cpu_platform_unary_rest_from_dict():
+    test_set_min_cpu_platform_unary_rest(request_type=dict)
 
 
-def test_set_min_cpu_platform_rest_flattened(transport: str = "rest"):
+def test_set_min_cpu_platform_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4872,7 +4874,7 @@ def test_set_min_cpu_platform_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_min_cpu_platform(**mock_args)
+        client.set_min_cpu_platform_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -4885,7 +4887,7 @@ def test_set_min_cpu_platform_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_min_cpu_platform_rest_flattened_error(transport: str = "rest"):
+def test_set_min_cpu_platform_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -4893,7 +4895,7 @@ def test_set_min_cpu_platform_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_min_cpu_platform(
+        client.set_min_cpu_platform_unary(
             compute.SetMinCpuPlatformInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -4904,7 +4906,7 @@ def test_set_min_cpu_platform_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_scheduling_rest(
+def test_set_scheduling_unary_rest(
     transport: str = "rest", request_type=compute.SetSchedulingInstanceRequest
 ):
     client = InstancesClient(
@@ -4950,7 +4952,7 @@ def test_set_scheduling_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_scheduling(request)
+        response = client.set_scheduling_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -4978,7 +4980,7 @@ def test_set_scheduling_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_scheduling_rest_bad_request(
+def test_set_scheduling_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetSchedulingInstanceRequest
 ):
     client = InstancesClient(
@@ -4999,14 +5001,14 @@ def test_set_scheduling_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_scheduling(request)
+        client.set_scheduling_unary(request)
 
 
-def test_set_scheduling_rest_from_dict():
-    test_set_scheduling_rest(request_type=dict)
+def test_set_scheduling_unary_rest_from_dict():
+    test_set_scheduling_unary_rest(request_type=dict)
 
 
-def test_set_scheduling_rest_flattened(transport: str = "rest"):
+def test_set_scheduling_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5039,7 +5041,7 @@ def test_set_scheduling_rest_flattened(transport: str = "rest"):
             scheduling_resource=compute.Scheduling(automatic_restart=True),
         )
         mock_args.update(sample_request)
-        client.set_scheduling(**mock_args)
+        client.set_scheduling_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5052,7 +5054,7 @@ def test_set_scheduling_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_scheduling_rest_flattened_error(transport: str = "rest"):
+def test_set_scheduling_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5060,7 +5062,7 @@ def test_set_scheduling_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_scheduling(
+        client.set_scheduling_unary(
             compute.SetSchedulingInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5069,7 +5071,7 @@ def test_set_scheduling_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_service_account_rest(
+def test_set_service_account_unary_rest(
     transport: str = "rest", request_type=compute.SetServiceAccountInstanceRequest
 ):
     client = InstancesClient(
@@ -5117,7 +5119,7 @@ def test_set_service_account_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_service_account(request)
+        response = client.set_service_account_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5145,7 +5147,7 @@ def test_set_service_account_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_service_account_rest_bad_request(
+def test_set_service_account_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetServiceAccountInstanceRequest
 ):
     client = InstancesClient(
@@ -5168,14 +5170,14 @@ def test_set_service_account_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_service_account(request)
+        client.set_service_account_unary(request)
 
 
-def test_set_service_account_rest_from_dict():
-    test_set_service_account_rest(request_type=dict)
+def test_set_service_account_unary_rest_from_dict():
+    test_set_service_account_unary_rest(request_type=dict)
 
 
-def test_set_service_account_rest_flattened(transport: str = "rest"):
+def test_set_service_account_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5210,7 +5212,7 @@ def test_set_service_account_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_service_account(**mock_args)
+        client.set_service_account_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5223,7 +5225,7 @@ def test_set_service_account_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_service_account_rest_flattened_error(transport: str = "rest"):
+def test_set_service_account_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5231,7 +5233,7 @@ def test_set_service_account_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_service_account(
+        client.set_service_account_unary(
             compute.SetServiceAccountInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5242,7 +5244,7 @@ def test_set_service_account_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_shielded_instance_integrity_policy_rest(
+def test_set_shielded_instance_integrity_policy_unary_rest(
     transport: str = "rest",
     request_type=compute.SetShieldedInstanceIntegrityPolicyInstanceRequest,
 ):
@@ -5291,7 +5293,7 @@ def test_set_shielded_instance_integrity_policy_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_shielded_instance_integrity_policy(request)
+        response = client.set_shielded_instance_integrity_policy_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5319,7 +5321,7 @@ def test_set_shielded_instance_integrity_policy_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_shielded_instance_integrity_policy_rest_bad_request(
+def test_set_shielded_instance_integrity_policy_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetShieldedInstanceIntegrityPolicyInstanceRequest,
 ):
@@ -5343,14 +5345,16 @@ def test_set_shielded_instance_integrity_policy_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_shielded_instance_integrity_policy(request)
+        client.set_shielded_instance_integrity_policy_unary(request)
 
 
-def test_set_shielded_instance_integrity_policy_rest_from_dict():
-    test_set_shielded_instance_integrity_policy_rest(request_type=dict)
+def test_set_shielded_instance_integrity_policy_unary_rest_from_dict():
+    test_set_shielded_instance_integrity_policy_unary_rest(request_type=dict)
 
 
-def test_set_shielded_instance_integrity_policy_rest_flattened(transport: str = "rest"):
+def test_set_shielded_instance_integrity_policy_unary_rest_flattened(
+    transport: str = "rest",
+):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5385,7 +5389,7 @@ def test_set_shielded_instance_integrity_policy_rest_flattened(transport: str = 
             ),
         )
         mock_args.update(sample_request)
-        client.set_shielded_instance_integrity_policy(**mock_args)
+        client.set_shielded_instance_integrity_policy_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5398,7 +5402,7 @@ def test_set_shielded_instance_integrity_policy_rest_flattened(transport: str = 
         )
 
 
-def test_set_shielded_instance_integrity_policy_rest_flattened_error(
+def test_set_shielded_instance_integrity_policy_unary_rest_flattened_error(
     transport: str = "rest",
 ):
     client = InstancesClient(
@@ -5408,7 +5412,7 @@ def test_set_shielded_instance_integrity_policy_rest_flattened_error(
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_shielded_instance_integrity_policy(
+        client.set_shielded_instance_integrity_policy_unary(
             compute.SetShieldedInstanceIntegrityPolicyInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5419,7 +5423,7 @@ def test_set_shielded_instance_integrity_policy_rest_flattened_error(
         )
 
 
-def test_set_tags_rest(
+def test_set_tags_unary_rest(
     transport: str = "rest", request_type=compute.SetTagsInstanceRequest
 ):
     client = InstancesClient(
@@ -5465,7 +5469,7 @@ def test_set_tags_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_tags(request)
+        response = client.set_tags_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5493,7 +5497,7 @@ def test_set_tags_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_tags_rest_bad_request(
+def test_set_tags_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetTagsInstanceRequest
 ):
     client = InstancesClient(
@@ -5514,14 +5518,14 @@ def test_set_tags_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_tags(request)
+        client.set_tags_unary(request)
 
 
-def test_set_tags_rest_from_dict():
-    test_set_tags_rest(request_type=dict)
+def test_set_tags_unary_rest_from_dict():
+    test_set_tags_unary_rest(request_type=dict)
 
 
-def test_set_tags_rest_flattened(transport: str = "rest"):
+def test_set_tags_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5554,7 +5558,7 @@ def test_set_tags_rest_flattened(transport: str = "rest"):
             tags_resource=compute.Tags(fingerprint="fingerprint_value"),
         )
         mock_args.update(sample_request)
-        client.set_tags(**mock_args)
+        client.set_tags_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5567,7 +5571,7 @@ def test_set_tags_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_tags_rest_flattened_error(transport: str = "rest"):
+def test_set_tags_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5575,7 +5579,7 @@ def test_set_tags_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_tags(
+        client.set_tags_unary(
             compute.SetTagsInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5584,7 +5588,7 @@ def test_set_tags_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_simulate_maintenance_event_rest(
+def test_simulate_maintenance_event_unary_rest(
     transport: str = "rest",
     request_type=compute.SimulateMaintenanceEventInstanceRequest,
 ):
@@ -5630,7 +5634,7 @@ def test_simulate_maintenance_event_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.simulate_maintenance_event(request)
+        response = client.simulate_maintenance_event_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5658,7 +5662,7 @@ def test_simulate_maintenance_event_rest(
     assert response.zone == "zone_value"
 
 
-def test_simulate_maintenance_event_rest_bad_request(
+def test_simulate_maintenance_event_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SimulateMaintenanceEventInstanceRequest,
 ):
@@ -5679,14 +5683,14 @@ def test_simulate_maintenance_event_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.simulate_maintenance_event(request)
+        client.simulate_maintenance_event_unary(request)
 
 
-def test_simulate_maintenance_event_rest_from_dict():
-    test_simulate_maintenance_event_rest(request_type=dict)
+def test_simulate_maintenance_event_unary_rest_from_dict():
+    test_simulate_maintenance_event_unary_rest(request_type=dict)
 
 
-def test_simulate_maintenance_event_rest_flattened(transport: str = "rest"):
+def test_simulate_maintenance_event_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5716,7 +5720,7 @@ def test_simulate_maintenance_event_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", instance="instance_value",
         )
         mock_args.update(sample_request)
-        client.simulate_maintenance_event(**mock_args)
+        client.simulate_maintenance_event_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5729,7 +5733,7 @@ def test_simulate_maintenance_event_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_simulate_maintenance_event_rest_flattened_error(transport: str = "rest"):
+def test_simulate_maintenance_event_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5737,7 +5741,7 @@ def test_simulate_maintenance_event_rest_flattened_error(transport: str = "rest"
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.simulate_maintenance_event(
+        client.simulate_maintenance_event_unary(
             compute.SimulateMaintenanceEventInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5745,7 +5749,9 @@ def test_simulate_maintenance_event_rest_flattened_error(transport: str = "rest"
         )
 
 
-def test_start_rest(transport: str = "rest", request_type=compute.StartInstanceRequest):
+def test_start_unary_rest(
+    transport: str = "rest", request_type=compute.StartInstanceRequest
+):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5788,7 +5794,7 @@ def test_start_rest(transport: str = "rest", request_type=compute.StartInstanceR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.start(request)
+        response = client.start_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5816,7 +5822,7 @@ def test_start_rest(transport: str = "rest", request_type=compute.StartInstanceR
     assert response.zone == "zone_value"
 
 
-def test_start_rest_bad_request(
+def test_start_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.StartInstanceRequest
 ):
     client = InstancesClient(
@@ -5836,14 +5842,14 @@ def test_start_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.start(request)
+        client.start_unary(request)
 
 
-def test_start_rest_from_dict():
-    test_start_rest(request_type=dict)
+def test_start_unary_rest_from_dict():
+    test_start_unary_rest(request_type=dict)
 
 
-def test_start_rest_flattened(transport: str = "rest"):
+def test_start_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5873,7 +5879,7 @@ def test_start_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", instance="instance_value",
         )
         mock_args.update(sample_request)
-        client.start(**mock_args)
+        client.start_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -5886,7 +5892,7 @@ def test_start_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_start_rest_flattened_error(transport: str = "rest"):
+def test_start_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -5894,7 +5900,7 @@ def test_start_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.start(
+        client.start_unary(
             compute.StartInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -5902,7 +5908,7 @@ def test_start_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_start_with_encryption_key_rest(
+def test_start_with_encryption_key_unary_rest(
     transport: str = "rest", request_type=compute.StartWithEncryptionKeyInstanceRequest
 ):
     client = InstancesClient(
@@ -5958,7 +5964,7 @@ def test_start_with_encryption_key_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.start_with_encryption_key(request)
+        response = client.start_with_encryption_key_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -5986,7 +5992,7 @@ def test_start_with_encryption_key_rest(
     assert response.zone == "zone_value"
 
 
-def test_start_with_encryption_key_rest_bad_request(
+def test_start_with_encryption_key_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.StartWithEncryptionKeyInstanceRequest
 ):
     client = InstancesClient(
@@ -6017,14 +6023,14 @@ def test_start_with_encryption_key_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.start_with_encryption_key(request)
+        client.start_with_encryption_key_unary(request)
 
 
-def test_start_with_encryption_key_rest_from_dict():
-    test_start_with_encryption_key_rest(request_type=dict)
+def test_start_with_encryption_key_unary_rest_from_dict():
+    test_start_with_encryption_key_unary_rest(request_type=dict)
 
 
-def test_start_with_encryption_key_rest_flattened(transport: str = "rest"):
+def test_start_with_encryption_key_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6065,7 +6071,7 @@ def test_start_with_encryption_key_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.start_with_encryption_key(**mock_args)
+        client.start_with_encryption_key_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -6078,7 +6084,7 @@ def test_start_with_encryption_key_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_start_with_encryption_key_rest_flattened_error(transport: str = "rest"):
+def test_start_with_encryption_key_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6086,7 +6092,7 @@ def test_start_with_encryption_key_rest_flattened_error(transport: str = "rest")
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.start_with_encryption_key(
+        client.start_with_encryption_key_unary(
             compute.StartWithEncryptionKeyInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -6103,7 +6109,9 @@ def test_start_with_encryption_key_rest_flattened_error(transport: str = "rest")
         )
 
 
-def test_stop_rest(transport: str = "rest", request_type=compute.StopInstanceRequest):
+def test_stop_unary_rest(
+    transport: str = "rest", request_type=compute.StopInstanceRequest
+):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6146,7 +6154,7 @@ def test_stop_rest(transport: str = "rest", request_type=compute.StopInstanceReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.stop(request)
+        response = client.stop_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -6174,7 +6182,7 @@ def test_stop_rest(transport: str = "rest", request_type=compute.StopInstanceReq
     assert response.zone == "zone_value"
 
 
-def test_stop_rest_bad_request(
+def test_stop_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.StopInstanceRequest
 ):
     client = InstancesClient(
@@ -6194,14 +6202,14 @@ def test_stop_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.stop(request)
+        client.stop_unary(request)
 
 
-def test_stop_rest_from_dict():
-    test_stop_rest(request_type=dict)
+def test_stop_unary_rest_from_dict():
+    test_stop_unary_rest(request_type=dict)
 
 
-def test_stop_rest_flattened(transport: str = "rest"):
+def test_stop_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6231,7 +6239,7 @@ def test_stop_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", instance="instance_value",
         )
         mock_args.update(sample_request)
-        client.stop(**mock_args)
+        client.stop_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -6244,7 +6252,7 @@ def test_stop_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_stop_rest_flattened_error(transport: str = "rest"):
+def test_stop_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6252,7 +6260,7 @@ def test_stop_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.stop(
+        client.stop_unary(
             compute.StopInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -6391,7 +6399,7 @@ def test_test_iam_permissions_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateInstanceRequest
 ):
     client = InstancesClient(
@@ -6441,7 +6449,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -6469,7 +6477,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateInstanceRequest
 ):
     client = InstancesClient(
@@ -6494,14 +6502,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6538,7 +6546,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -6551,7 +6559,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6559,7 +6567,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -6572,7 +6580,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_access_config_rest(
+def test_update_access_config_unary_rest(
     transport: str = "rest", request_type=compute.UpdateAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -6620,7 +6628,7 @@ def test_update_access_config_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_access_config(request)
+        response = client.update_access_config_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -6648,7 +6656,7 @@ def test_update_access_config_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_access_config_rest_bad_request(
+def test_update_access_config_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateAccessConfigInstanceRequest
 ):
     client = InstancesClient(
@@ -6671,14 +6679,14 @@ def test_update_access_config_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_access_config(request)
+        client.update_access_config_unary(request)
 
 
-def test_update_access_config_rest_from_dict():
-    test_update_access_config_rest(request_type=dict)
+def test_update_access_config_unary_rest_from_dict():
+    test_update_access_config_unary_rest(request_type=dict)
 
 
-def test_update_access_config_rest_flattened(transport: str = "rest"):
+def test_update_access_config_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6714,7 +6722,7 @@ def test_update_access_config_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update_access_config(**mock_args)
+        client.update_access_config_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -6727,7 +6735,7 @@ def test_update_access_config_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_access_config_rest_flattened_error(transport: str = "rest"):
+def test_update_access_config_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6735,7 +6743,7 @@ def test_update_access_config_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_access_config(
+        client.update_access_config_unary(
             compute.UpdateAccessConfigInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -6747,7 +6755,7 @@ def test_update_access_config_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_display_device_rest(
+def test_update_display_device_unary_rest(
     transport: str = "rest", request_type=compute.UpdateDisplayDeviceInstanceRequest
 ):
     client = InstancesClient(
@@ -6793,7 +6801,7 @@ def test_update_display_device_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_display_device(request)
+        response = client.update_display_device_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -6821,7 +6829,7 @@ def test_update_display_device_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_display_device_rest_bad_request(
+def test_update_display_device_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateDisplayDeviceInstanceRequest
 ):
     client = InstancesClient(
@@ -6842,14 +6850,14 @@ def test_update_display_device_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_display_device(request)
+        client.update_display_device_unary(request)
 
 
-def test_update_display_device_rest_from_dict():
-    test_update_display_device_rest(request_type=dict)
+def test_update_display_device_unary_rest_from_dict():
+    test_update_display_device_unary_rest(request_type=dict)
 
 
-def test_update_display_device_rest_flattened(transport: str = "rest"):
+def test_update_display_device_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6882,7 +6890,7 @@ def test_update_display_device_rest_flattened(transport: str = "rest"):
             display_device_resource=compute.DisplayDevice(enable_display=True),
         )
         mock_args.update(sample_request)
-        client.update_display_device(**mock_args)
+        client.update_display_device_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -6895,7 +6903,7 @@ def test_update_display_device_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_display_device_rest_flattened_error(transport: str = "rest"):
+def test_update_display_device_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -6903,7 +6911,7 @@ def test_update_display_device_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_display_device(
+        client.update_display_device_unary(
             compute.UpdateDisplayDeviceInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -6912,7 +6920,7 @@ def test_update_display_device_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_network_interface_rest(
+def test_update_network_interface_unary_rest(
     transport: str = "rest", request_type=compute.UpdateNetworkInterfaceInstanceRequest
 ):
     client = InstancesClient(
@@ -6960,7 +6968,7 @@ def test_update_network_interface_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_network_interface(request)
+        response = client.update_network_interface_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -6988,7 +6996,7 @@ def test_update_network_interface_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_network_interface_rest_bad_request(
+def test_update_network_interface_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateNetworkInterfaceInstanceRequest
 ):
     client = InstancesClient(
@@ -7011,14 +7019,14 @@ def test_update_network_interface_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_network_interface(request)
+        client.update_network_interface_unary(request)
 
 
-def test_update_network_interface_rest_from_dict():
-    test_update_network_interface_rest(request_type=dict)
+def test_update_network_interface_unary_rest_from_dict():
+    test_update_network_interface_unary_rest(request_type=dict)
 
 
-def test_update_network_interface_rest_flattened(transport: str = "rest"):
+def test_update_network_interface_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -7056,7 +7064,7 @@ def test_update_network_interface_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update_network_interface(**mock_args)
+        client.update_network_interface_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -7069,7 +7077,7 @@ def test_update_network_interface_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_network_interface_rest_flattened_error(transport: str = "rest"):
+def test_update_network_interface_unary_rest_flattened_error(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -7077,7 +7085,7 @@ def test_update_network_interface_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_network_interface(
+        client.update_network_interface_unary(
             compute.UpdateNetworkInterfaceInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -7091,7 +7099,7 @@ def test_update_network_interface_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_shielded_instance_config_rest(
+def test_update_shielded_instance_config_unary_rest(
     transport: str = "rest",
     request_type=compute.UpdateShieldedInstanceConfigInstanceRequest,
 ):
@@ -7140,7 +7148,7 @@ def test_update_shielded_instance_config_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_shielded_instance_config(request)
+        response = client.update_shielded_instance_config_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -7168,7 +7176,7 @@ def test_update_shielded_instance_config_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_shielded_instance_config_rest_bad_request(
+def test_update_shielded_instance_config_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.UpdateShieldedInstanceConfigInstanceRequest,
 ):
@@ -7192,14 +7200,14 @@ def test_update_shielded_instance_config_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_shielded_instance_config(request)
+        client.update_shielded_instance_config_unary(request)
 
 
-def test_update_shielded_instance_config_rest_from_dict():
-    test_update_shielded_instance_config_rest(request_type=dict)
+def test_update_shielded_instance_config_unary_rest_from_dict():
+    test_update_shielded_instance_config_unary_rest(request_type=dict)
 
 
-def test_update_shielded_instance_config_rest_flattened(transport: str = "rest"):
+def test_update_shielded_instance_config_unary_rest_flattened(transport: str = "rest"):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -7234,7 +7242,7 @@ def test_update_shielded_instance_config_rest_flattened(transport: str = "rest")
             ),
         )
         mock_args.update(sample_request)
-        client.update_shielded_instance_config(**mock_args)
+        client.update_shielded_instance_config_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -7247,7 +7255,9 @@ def test_update_shielded_instance_config_rest_flattened(transport: str = "rest")
         )
 
 
-def test_update_shielded_instance_config_rest_flattened_error(transport: str = "rest"):
+def test_update_shielded_instance_config_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = InstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -7255,7 +7265,7 @@ def test_update_shielded_instance_config_rest_flattened_error(transport: str = "
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_shielded_instance_config(
+        client.update_shielded_instance_config_unary(
             compute.UpdateShieldedInstanceConfigInstanceRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_interconnect_attachments.py
+++ b/tests/unit/gapic/compute_v1/test_interconnect_attachments.py
@@ -634,7 +634,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -683,7 +683,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -711,7 +711,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -735,14 +735,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -774,7 +774,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             interconnect_attachment="interconnect_attachment_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -787,7 +787,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -795,7 +795,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInterconnectAttachmentRequest(),
             project="project_value",
             region="region_value",
@@ -982,7 +982,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -1030,7 +1030,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1058,7 +1058,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -1081,14 +1081,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1118,7 +1118,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1131,7 +1131,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1139,7 +1139,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInterconnectAttachmentRequest(),
             project="project_value",
             region="region_value",
@@ -1321,7 +1321,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -1373,7 +1373,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1401,7 +1401,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchInterconnectAttachmentRequest
 ):
     client = InterconnectAttachmentsClient(
@@ -1428,14 +1428,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1470,7 +1470,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1483,7 +1483,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1491,7 +1491,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchInterconnectAttachmentRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_interconnects.py
+++ b/tests/unit/gapic/compute_v1/test_interconnects.py
@@ -408,7 +408,7 @@ def test_interconnects_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -453,7 +453,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -481,7 +481,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -501,14 +501,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -532,7 +532,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", interconnect="interconnect_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -545,7 +545,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -553,7 +553,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteInterconnectRequest(),
             project="project_value",
             interconnect="interconnect_value",
@@ -819,7 +819,7 @@ def test_get_diagnostics_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -865,7 +865,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -893,7 +893,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -914,14 +914,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -948,7 +948,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             interconnect_resource=compute.Interconnect(admin_enabled=True),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -961,7 +961,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -969,7 +969,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertInterconnectRequest(),
             project="project_value",
             interconnect_resource=compute.Interconnect(admin_enabled=True),
@@ -1139,7 +1139,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -1185,7 +1185,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1213,7 +1213,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchInterconnectRequest
 ):
     client = InterconnectsClient(
@@ -1234,14 +1234,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1269,7 +1269,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             interconnect_resource=compute.Interconnect(admin_enabled=True),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1282,7 +1282,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = InterconnectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1290,7 +1290,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchInterconnectRequest(),
             project="project_value",
             interconnect="interconnect_value",

--- a/tests/unit/gapic/compute_v1/test_licenses.py
+++ b/tests/unit/gapic/compute_v1/test_licenses.py
@@ -397,7 +397,7 @@ def test_licenses_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteLicenseRequest
 ):
     client = LicensesClient(
@@ -442,7 +442,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -470,7 +470,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteLicenseRequest
 ):
     client = LicensesClient(
@@ -490,14 +490,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = LicensesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -521,7 +521,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", license_="license__value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -534,7 +534,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = LicensesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,7 +542,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteLicenseRequest(),
             project="project_value",
             license_="license__value",
@@ -783,7 +783,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertLicenseRequest
 ):
     client = LicensesClient(
@@ -829,7 +829,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -857,7 +857,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertLicenseRequest
 ):
     client = LicensesClient(
@@ -878,14 +878,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = LicensesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -912,7 +912,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             license_resource=compute.License(charges_use_fee=True),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -925,7 +925,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = LicensesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -933,7 +933,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertLicenseRequest(),
             project="project_value",
             license_resource=compute.License(charges_use_fee=True),

--- a/tests/unit/gapic/compute_v1/test_network_endpoint_groups.py
+++ b/tests/unit/gapic/compute_v1/test_network_endpoint_groups.py
@@ -634,7 +634,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_attach_network_endpoints_rest(
+def test_attach_network_endpoints_unary_rest(
     transport: str = "rest",
     request_type=compute.AttachNetworkEndpointsNetworkEndpointGroupRequest,
 ):
@@ -691,7 +691,7 @@ def test_attach_network_endpoints_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.attach_network_endpoints(request)
+        response = client.attach_network_endpoints_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -719,7 +719,7 @@ def test_attach_network_endpoints_rest(
     assert response.zone == "zone_value"
 
 
-def test_attach_network_endpoints_rest_bad_request(
+def test_attach_network_endpoints_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.AttachNetworkEndpointsNetworkEndpointGroupRequest,
 ):
@@ -751,14 +751,14 @@ def test_attach_network_endpoints_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.attach_network_endpoints(request)
+        client.attach_network_endpoints_unary(request)
 
 
-def test_attach_network_endpoints_rest_from_dict():
-    test_attach_network_endpoints_rest(request_type=dict)
+def test_attach_network_endpoints_unary_rest_from_dict():
+    test_attach_network_endpoints_unary_rest(request_type=dict)
 
 
-def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
+def test_attach_network_endpoints_unary_rest_flattened(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -795,7 +795,7 @@ def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.attach_network_endpoints(**mock_args)
+        client.attach_network_endpoints_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -808,7 +808,7 @@ def test_attach_network_endpoints_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
+def test_attach_network_endpoints_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -816,7 +816,7 @@ def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.attach_network_endpoints(
+        client.attach_network_endpoints_unary(
             compute.AttachNetworkEndpointsNetworkEndpointGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -829,7 +829,7 @@ def test_attach_network_endpoints_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteNetworkEndpointGroupRequest
 ):
     client = NetworkEndpointGroupsClient(
@@ -878,7 +878,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -906,7 +906,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteNetworkEndpointGroupRequest
 ):
     client = NetworkEndpointGroupsClient(
@@ -930,14 +930,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -969,7 +969,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             network_endpoint_group="network_endpoint_group_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -982,7 +982,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -990,7 +990,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteNetworkEndpointGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -998,7 +998,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_detach_network_endpoints_rest(
+def test_detach_network_endpoints_unary_rest(
     transport: str = "rest",
     request_type=compute.DetachNetworkEndpointsNetworkEndpointGroupRequest,
 ):
@@ -1055,7 +1055,7 @@ def test_detach_network_endpoints_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.detach_network_endpoints(request)
+        response = client.detach_network_endpoints_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1083,7 +1083,7 @@ def test_detach_network_endpoints_rest(
     assert response.zone == "zone_value"
 
 
-def test_detach_network_endpoints_rest_bad_request(
+def test_detach_network_endpoints_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DetachNetworkEndpointsNetworkEndpointGroupRequest,
 ):
@@ -1115,14 +1115,14 @@ def test_detach_network_endpoints_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.detach_network_endpoints(request)
+        client.detach_network_endpoints_unary(request)
 
 
-def test_detach_network_endpoints_rest_from_dict():
-    test_detach_network_endpoints_rest(request_type=dict)
+def test_detach_network_endpoints_unary_rest_from_dict():
+    test_detach_network_endpoints_unary_rest(request_type=dict)
 
 
-def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
+def test_detach_network_endpoints_unary_rest_flattened(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1159,7 +1159,7 @@ def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.detach_network_endpoints(**mock_args)
+        client.detach_network_endpoints_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1172,7 +1172,7 @@ def test_detach_network_endpoints_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_detach_network_endpoints_rest_flattened_error(transport: str = "rest"):
+def test_detach_network_endpoints_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1180,7 +1180,7 @@ def test_detach_network_endpoints_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.detach_network_endpoints(
+        client.detach_network_endpoints_unary(
             compute.DetachNetworkEndpointsNetworkEndpointGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1344,7 +1344,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertNetworkEndpointGroupRequest
 ):
     client = NetworkEndpointGroupsClient(
@@ -1392,7 +1392,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1420,7 +1420,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertNetworkEndpointGroupRequest
 ):
     client = NetworkEndpointGroupsClient(
@@ -1443,14 +1443,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1480,7 +1480,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1493,7 +1493,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1501,7 +1501,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertNetworkEndpointGroupRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_networks.py
+++ b/tests/unit/gapic/compute_v1/test_networks.py
@@ -397,7 +397,7 @@ def test_networks_client_client_options_credentials_file(
         )
 
 
-def test_add_peering_rest(
+def test_add_peering_unary_rest(
     transport: str = "rest", request_type=compute.AddPeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -445,7 +445,7 @@ def test_add_peering_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_peering(request)
+        response = client.add_peering_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -473,7 +473,7 @@ def test_add_peering_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_peering_rest_bad_request(
+def test_add_peering_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddPeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -496,14 +496,14 @@ def test_add_peering_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_peering(request)
+        client.add_peering_unary(request)
 
 
-def test_add_peering_rest_from_dict():
-    test_add_peering_rest(request_type=dict)
+def test_add_peering_unary_rest_from_dict():
+    test_add_peering_unary_rest(request_type=dict)
 
 
-def test_add_peering_rest_flattened(transport: str = "rest"):
+def test_add_peering_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -533,7 +533,7 @@ def test_add_peering_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_peering(**mock_args)
+        client.add_peering_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -546,7 +546,7 @@ def test_add_peering_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_peering_rest_flattened_error(transport: str = "rest"):
+def test_add_peering_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -554,7 +554,7 @@ def test_add_peering_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_peering(
+        client.add_peering_unary(
             compute.AddPeeringNetworkRequest(),
             project="project_value",
             network="network_value",
@@ -564,7 +564,7 @@ def test_add_peering_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteNetworkRequest
 ):
     client = NetworksClient(
@@ -609,7 +609,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -637,7 +637,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteNetworkRequest
 ):
     client = NetworksClient(
@@ -657,14 +657,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -688,7 +688,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", network="network_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -701,7 +701,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -709,7 +709,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteNetworkRequest(),
             project="project_value",
             network="network_value",
@@ -955,7 +955,7 @@ def test_get_effective_firewalls_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertNetworkRequest
 ):
     client = NetworksClient(
@@ -1001,7 +1001,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1029,7 +1029,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertNetworkRequest
 ):
     client = NetworksClient(
@@ -1050,14 +1050,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1084,7 +1084,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             network_resource=compute.Network(I_pv4_range="I_pv4_range_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1097,7 +1097,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1105,7 +1105,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertNetworkRequest(),
             project="project_value",
             network_resource=compute.Network(I_pv4_range="I_pv4_range_value"),
@@ -1435,7 +1435,9 @@ def test_list_peering_routes_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(transport: str = "rest", request_type=compute.PatchNetworkRequest):
+def test_patch_unary_rest(
+    transport: str = "rest", request_type=compute.PatchNetworkRequest
+):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1479,7 +1481,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchNetworkRe
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1507,7 +1509,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchNetworkRe
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchNetworkRequest
 ):
     client = NetworksClient(
@@ -1528,14 +1530,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1563,7 +1565,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             network_resource=compute.Network(I_pv4_range="I_pv4_range_value"),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1576,7 +1578,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1584,7 +1586,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchNetworkRequest(),
             project="project_value",
             network="network_value",
@@ -1592,7 +1594,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_remove_peering_rest(
+def test_remove_peering_unary_rest(
     transport: str = "rest", request_type=compute.RemovePeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -1640,7 +1642,7 @@ def test_remove_peering_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_peering(request)
+        response = client.remove_peering_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1668,7 +1670,7 @@ def test_remove_peering_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_peering_rest_bad_request(
+def test_remove_peering_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemovePeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -1691,14 +1693,14 @@ def test_remove_peering_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_peering(request)
+        client.remove_peering_unary(request)
 
 
-def test_remove_peering_rest_from_dict():
-    test_remove_peering_rest(request_type=dict)
+def test_remove_peering_unary_rest_from_dict():
+    test_remove_peering_unary_rest(request_type=dict)
 
 
-def test_remove_peering_rest_flattened(transport: str = "rest"):
+def test_remove_peering_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1728,7 +1730,7 @@ def test_remove_peering_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_peering(**mock_args)
+        client.remove_peering_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1741,7 +1743,7 @@ def test_remove_peering_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_peering_rest_flattened_error(transport: str = "rest"):
+def test_remove_peering_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1749,7 +1751,7 @@ def test_remove_peering_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_peering(
+        client.remove_peering_unary(
             compute.RemovePeeringNetworkRequest(),
             project="project_value",
             network="network_value",
@@ -1759,7 +1761,7 @@ def test_remove_peering_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_switch_to_custom_mode_rest(
+def test_switch_to_custom_mode_unary_rest(
     transport: str = "rest", request_type=compute.SwitchToCustomModeNetworkRequest
 ):
     client = NetworksClient(
@@ -1804,7 +1806,7 @@ def test_switch_to_custom_mode_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.switch_to_custom_mode(request)
+        response = client.switch_to_custom_mode_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1832,7 +1834,7 @@ def test_switch_to_custom_mode_rest(
     assert response.zone == "zone_value"
 
 
-def test_switch_to_custom_mode_rest_bad_request(
+def test_switch_to_custom_mode_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SwitchToCustomModeNetworkRequest
 ):
     client = NetworksClient(
@@ -1852,14 +1854,14 @@ def test_switch_to_custom_mode_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.switch_to_custom_mode(request)
+        client.switch_to_custom_mode_unary(request)
 
 
-def test_switch_to_custom_mode_rest_from_dict():
-    test_switch_to_custom_mode_rest(request_type=dict)
+def test_switch_to_custom_mode_unary_rest_from_dict():
+    test_switch_to_custom_mode_unary_rest(request_type=dict)
 
 
-def test_switch_to_custom_mode_rest_flattened(transport: str = "rest"):
+def test_switch_to_custom_mode_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1883,7 +1885,7 @@ def test_switch_to_custom_mode_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", network="network_value",)
         mock_args.update(sample_request)
-        client.switch_to_custom_mode(**mock_args)
+        client.switch_to_custom_mode_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1896,7 +1898,7 @@ def test_switch_to_custom_mode_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_switch_to_custom_mode_rest_flattened_error(transport: str = "rest"):
+def test_switch_to_custom_mode_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1904,14 +1906,14 @@ def test_switch_to_custom_mode_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.switch_to_custom_mode(
+        client.switch_to_custom_mode_unary(
             compute.SwitchToCustomModeNetworkRequest(),
             project="project_value",
             network="network_value",
         )
 
 
-def test_update_peering_rest(
+def test_update_peering_unary_rest(
     transport: str = "rest", request_type=compute.UpdatePeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -1961,7 +1963,7 @@ def test_update_peering_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_peering(request)
+        response = client.update_peering_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1989,7 +1991,7 @@ def test_update_peering_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_peering_rest_bad_request(
+def test_update_peering_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdatePeeringNetworkRequest
 ):
     client = NetworksClient(
@@ -2014,14 +2016,14 @@ def test_update_peering_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_peering(request)
+        client.update_peering_unary(request)
 
 
-def test_update_peering_rest_from_dict():
-    test_update_peering_rest(request_type=dict)
+def test_update_peering_unary_rest_from_dict():
+    test_update_peering_unary_rest(request_type=dict)
 
 
-def test_update_peering_rest_flattened(transport: str = "rest"):
+def test_update_peering_unary_rest_flattened(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2051,7 +2053,7 @@ def test_update_peering_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update_peering(**mock_args)
+        client.update_peering_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2064,7 +2066,7 @@ def test_update_peering_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_peering_rest_flattened_error(transport: str = "rest"):
+def test_update_peering_unary_rest_flattened_error(transport: str = "rest"):
     client = NetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2072,7 +2074,7 @@ def test_update_peering_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_peering(
+        client.update_peering_unary(
             compute.UpdatePeeringNetworkRequest(),
             project="project_value",
             network="network_value",

--- a/tests/unit/gapic/compute_v1/test_node_groups.py
+++ b/tests/unit/gapic/compute_v1/test_node_groups.py
@@ -401,7 +401,7 @@ def test_node_groups_client_client_options_credentials_file(
         )
 
 
-def test_add_nodes_rest(
+def test_add_nodes_unary_rest(
     transport: str = "rest", request_type=compute.AddNodesNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -449,7 +449,7 @@ def test_add_nodes_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_nodes(request)
+        response = client.add_nodes_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -477,7 +477,7 @@ def test_add_nodes_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_nodes_rest_bad_request(
+def test_add_nodes_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddNodesNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -500,14 +500,14 @@ def test_add_nodes_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_nodes(request)
+        client.add_nodes_unary(request)
 
 
-def test_add_nodes_rest_from_dict():
-    test_add_nodes_rest(request_type=dict)
+def test_add_nodes_unary_rest_from_dict():
+    test_add_nodes_unary_rest(request_type=dict)
 
 
-def test_add_nodes_rest_flattened(transport: str = "rest"):
+def test_add_nodes_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,7 +542,7 @@ def test_add_nodes_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_nodes(**mock_args)
+        client.add_nodes_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -555,7 +555,7 @@ def test_add_nodes_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_nodes_rest_flattened_error(transport: str = "rest"):
+def test_add_nodes_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -563,7 +563,7 @@ def test_add_nodes_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_nodes(
+        client.add_nodes_unary(
             compute.AddNodesNodeGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -751,7 +751,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -796,7 +796,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -824,7 +824,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -844,14 +844,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -881,7 +881,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", node_group="node_group_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -894,7 +894,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -902,7 +902,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteNodeGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -910,7 +910,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_nodes_rest(
+def test_delete_nodes_unary_rest(
     transport: str = "rest", request_type=compute.DeleteNodesNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -958,7 +958,7 @@ def test_delete_nodes_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_nodes(request)
+        response = client.delete_nodes_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -986,7 +986,7 @@ def test_delete_nodes_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_nodes_rest_bad_request(
+def test_delete_nodes_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteNodesNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -1009,14 +1009,14 @@ def test_delete_nodes_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_nodes(request)
+        client.delete_nodes_unary(request)
 
 
-def test_delete_nodes_rest_from_dict():
-    test_delete_nodes_rest(request_type=dict)
+def test_delete_nodes_unary_rest_from_dict():
+    test_delete_nodes_unary_rest(request_type=dict)
 
 
-def test_delete_nodes_rest_flattened(transport: str = "rest"):
+def test_delete_nodes_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1051,7 +1051,7 @@ def test_delete_nodes_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.delete_nodes(**mock_args)
+        client.delete_nodes_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1064,7 +1064,7 @@ def test_delete_nodes_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_nodes_rest_flattened_error(transport: str = "rest"):
+def test_delete_nodes_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1072,7 +1072,7 @@ def test_delete_nodes_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_nodes(
+        client.delete_nodes_unary(
             compute.DeleteNodesNodeGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1339,7 +1339,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -1387,7 +1387,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1415,7 +1415,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -1438,14 +1438,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1476,7 +1476,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1489,7 +1489,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1497,7 +1497,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertNodeGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -1837,7 +1837,7 @@ def test_list_nodes_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -1885,7 +1885,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1913,7 +1913,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -1936,14 +1936,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1978,7 +1978,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1991,7 +1991,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1999,7 +1999,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchNodeGroupRequest(),
             project="project_value",
             zone="zone_value",
@@ -2141,7 +2141,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_node_template_rest(
+def test_set_node_template_unary_rest(
     transport: str = "rest", request_type=compute.SetNodeTemplateNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -2189,7 +2189,7 @@ def test_set_node_template_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_node_template(request)
+        response = client.set_node_template_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2217,7 +2217,7 @@ def test_set_node_template_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_node_template_rest_bad_request(
+def test_set_node_template_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetNodeTemplateNodeGroupRequest
 ):
     client = NodeGroupsClient(
@@ -2240,14 +2240,14 @@ def test_set_node_template_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_node_template(request)
+        client.set_node_template_unary(request)
 
 
-def test_set_node_template_rest_from_dict():
-    test_set_node_template_rest(request_type=dict)
+def test_set_node_template_unary_rest_from_dict():
+    test_set_node_template_unary_rest(request_type=dict)
 
 
-def test_set_node_template_rest_flattened(transport: str = "rest"):
+def test_set_node_template_unary_rest_flattened(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2282,7 +2282,7 @@ def test_set_node_template_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_node_template(**mock_args)
+        client.set_node_template_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2295,7 +2295,7 @@ def test_set_node_template_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_node_template_rest_flattened_error(transport: str = "rest"):
+def test_set_node_template_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2303,7 +2303,7 @@ def test_set_node_template_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_node_template(
+        client.set_node_template_unary(
             compute.SetNodeTemplateNodeGroupRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_node_templates.py
+++ b/tests/unit/gapic/compute_v1/test_node_templates.py
@@ -590,7 +590,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteNodeTemplateRequest
 ):
     client = NodeTemplatesClient(
@@ -639,7 +639,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -667,7 +667,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteNodeTemplateRequest
 ):
     client = NodeTemplatesClient(
@@ -691,14 +691,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = NodeTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -730,7 +730,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             node_template="node_template_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -743,7 +743,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -751,7 +751,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteNodeTemplateRequest(),
             project="project_value",
             region="region_value",
@@ -1021,7 +1021,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertNodeTemplateRequest
 ):
     client = NodeTemplatesClient(
@@ -1069,7 +1069,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1097,7 +1097,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertNodeTemplateRequest
 ):
     client = NodeTemplatesClient(
@@ -1120,14 +1120,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = NodeTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1157,7 +1157,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1170,7 +1170,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = NodeTemplatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1178,7 +1178,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertNodeTemplateRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_packet_mirrorings.py
+++ b/tests/unit/gapic/compute_v1/test_packet_mirrorings.py
@@ -603,7 +603,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeletePacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -652,7 +652,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -680,7 +680,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeletePacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -704,14 +704,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -743,7 +743,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             packet_mirroring="packet_mirroring_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -756,7 +756,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -764,7 +764,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeletePacketMirroringRequest(),
             project="project_value",
             region="region_value",
@@ -915,7 +915,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertPacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -965,7 +965,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -993,7 +993,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertPacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -1018,14 +1018,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1057,7 +1057,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1070,7 +1070,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1078,7 +1078,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertPacketMirroringRequest(),
             project="project_value",
             region="region_value",
@@ -1255,7 +1255,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchPacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -1309,7 +1309,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1337,7 +1337,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchPacketMirroringRequest
 ):
     client = PacketMirroringsClient(
@@ -1366,14 +1366,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1410,7 +1410,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1423,7 +1423,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = PacketMirroringsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1431,7 +1431,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchPacketMirroringRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_projects.py
+++ b/tests/unit/gapic/compute_v1/test_projects.py
@@ -397,7 +397,7 @@ def test_projects_client_client_options_credentials_file(
         )
 
 
-def test_disable_xpn_host_rest(
+def test_disable_xpn_host_unary_rest(
     transport: str = "rest", request_type=compute.DisableXpnHostProjectRequest
 ):
     client = ProjectsClient(
@@ -442,7 +442,7 @@ def test_disable_xpn_host_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.disable_xpn_host(request)
+        response = client.disable_xpn_host_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -470,7 +470,7 @@ def test_disable_xpn_host_rest(
     assert response.zone == "zone_value"
 
 
-def test_disable_xpn_host_rest_bad_request(
+def test_disable_xpn_host_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DisableXpnHostProjectRequest
 ):
     client = ProjectsClient(
@@ -490,14 +490,14 @@ def test_disable_xpn_host_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.disable_xpn_host(request)
+        client.disable_xpn_host_unary(request)
 
 
-def test_disable_xpn_host_rest_from_dict():
-    test_disable_xpn_host_rest(request_type=dict)
+def test_disable_xpn_host_unary_rest_from_dict():
+    test_disable_xpn_host_unary_rest(request_type=dict)
 
 
-def test_disable_xpn_host_rest_flattened(transport: str = "rest"):
+def test_disable_xpn_host_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -521,7 +521,7 @@ def test_disable_xpn_host_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value",)
         mock_args.update(sample_request)
-        client.disable_xpn_host(**mock_args)
+        client.disable_xpn_host_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -534,7 +534,7 @@ def test_disable_xpn_host_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_disable_xpn_host_rest_flattened_error(transport: str = "rest"):
+def test_disable_xpn_host_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,12 +542,12 @@ def test_disable_xpn_host_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.disable_xpn_host(
+        client.disable_xpn_host_unary(
             compute.DisableXpnHostProjectRequest(), project="project_value",
         )
 
 
-def test_disable_xpn_resource_rest(
+def test_disable_xpn_resource_unary_rest(
     transport: str = "rest", request_type=compute.DisableXpnResourceProjectRequest
 ):
     client = ProjectsClient(
@@ -597,7 +597,7 @@ def test_disable_xpn_resource_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.disable_xpn_resource(request)
+        response = client.disable_xpn_resource_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -625,7 +625,7 @@ def test_disable_xpn_resource_rest(
     assert response.zone == "zone_value"
 
 
-def test_disable_xpn_resource_rest_bad_request(
+def test_disable_xpn_resource_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DisableXpnResourceProjectRequest
 ):
     client = ProjectsClient(
@@ -650,14 +650,14 @@ def test_disable_xpn_resource_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.disable_xpn_resource(request)
+        client.disable_xpn_resource_unary(request)
 
 
-def test_disable_xpn_resource_rest_from_dict():
-    test_disable_xpn_resource_rest(request_type=dict)
+def test_disable_xpn_resource_unary_rest_from_dict():
+    test_disable_xpn_resource_unary_rest(request_type=dict)
 
 
-def test_disable_xpn_resource_rest_flattened(transport: str = "rest"):
+def test_disable_xpn_resource_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -686,7 +686,7 @@ def test_disable_xpn_resource_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.disable_xpn_resource(**mock_args)
+        client.disable_xpn_resource_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -699,7 +699,7 @@ def test_disable_xpn_resource_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_disable_xpn_resource_rest_flattened_error(transport: str = "rest"):
+def test_disable_xpn_resource_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -707,7 +707,7 @@ def test_disable_xpn_resource_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.disable_xpn_resource(
+        client.disable_xpn_resource_unary(
             compute.DisableXpnResourceProjectRequest(),
             project="project_value",
             projects_disable_xpn_resource_request_resource=compute.ProjectsDisableXpnResourceRequest(
@@ -716,7 +716,7 @@ def test_disable_xpn_resource_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_enable_xpn_host_rest(
+def test_enable_xpn_host_unary_rest(
     transport: str = "rest", request_type=compute.EnableXpnHostProjectRequest
 ):
     client = ProjectsClient(
@@ -761,7 +761,7 @@ def test_enable_xpn_host_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.enable_xpn_host(request)
+        response = client.enable_xpn_host_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -789,7 +789,7 @@ def test_enable_xpn_host_rest(
     assert response.zone == "zone_value"
 
 
-def test_enable_xpn_host_rest_bad_request(
+def test_enable_xpn_host_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.EnableXpnHostProjectRequest
 ):
     client = ProjectsClient(
@@ -809,14 +809,14 @@ def test_enable_xpn_host_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.enable_xpn_host(request)
+        client.enable_xpn_host_unary(request)
 
 
-def test_enable_xpn_host_rest_from_dict():
-    test_enable_xpn_host_rest(request_type=dict)
+def test_enable_xpn_host_unary_rest_from_dict():
+    test_enable_xpn_host_unary_rest(request_type=dict)
 
 
-def test_enable_xpn_host_rest_flattened(transport: str = "rest"):
+def test_enable_xpn_host_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -840,7 +840,7 @@ def test_enable_xpn_host_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value",)
         mock_args.update(sample_request)
-        client.enable_xpn_host(**mock_args)
+        client.enable_xpn_host_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -853,7 +853,7 @@ def test_enable_xpn_host_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_enable_xpn_host_rest_flattened_error(transport: str = "rest"):
+def test_enable_xpn_host_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -861,12 +861,12 @@ def test_enable_xpn_host_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.enable_xpn_host(
+        client.enable_xpn_host_unary(
             compute.EnableXpnHostProjectRequest(), project="project_value",
         )
 
 
-def test_enable_xpn_resource_rest(
+def test_enable_xpn_resource_unary_rest(
     transport: str = "rest", request_type=compute.EnableXpnResourceProjectRequest
 ):
     client = ProjectsClient(
@@ -916,7 +916,7 @@ def test_enable_xpn_resource_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.enable_xpn_resource(request)
+        response = client.enable_xpn_resource_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -944,7 +944,7 @@ def test_enable_xpn_resource_rest(
     assert response.zone == "zone_value"
 
 
-def test_enable_xpn_resource_rest_bad_request(
+def test_enable_xpn_resource_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.EnableXpnResourceProjectRequest
 ):
     client = ProjectsClient(
@@ -969,14 +969,14 @@ def test_enable_xpn_resource_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.enable_xpn_resource(request)
+        client.enable_xpn_resource_unary(request)
 
 
-def test_enable_xpn_resource_rest_from_dict():
-    test_enable_xpn_resource_rest(request_type=dict)
+def test_enable_xpn_resource_unary_rest_from_dict():
+    test_enable_xpn_resource_unary_rest(request_type=dict)
 
 
-def test_enable_xpn_resource_rest_flattened(transport: str = "rest"):
+def test_enable_xpn_resource_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1005,7 +1005,7 @@ def test_enable_xpn_resource_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.enable_xpn_resource(**mock_args)
+        client.enable_xpn_resource_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1018,7 +1018,7 @@ def test_enable_xpn_resource_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_enable_xpn_resource_rest_flattened_error(transport: str = "rest"):
+def test_enable_xpn_resource_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1026,7 +1026,7 @@ def test_enable_xpn_resource_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.enable_xpn_resource(
+        client.enable_xpn_resource_unary(
             compute.EnableXpnResourceProjectRequest(),
             project="project_value",
             projects_enable_xpn_resource_request_resource=compute.ProjectsEnableXpnResourceRequest(
@@ -1614,7 +1614,7 @@ def test_list_xpn_hosts_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_move_disk_rest(
+def test_move_disk_unary_rest(
     transport: str = "rest", request_type=compute.MoveDiskProjectRequest
 ):
     client = ProjectsClient(
@@ -1662,7 +1662,7 @@ def test_move_disk_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.move_disk(request)
+        response = client.move_disk_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1690,7 +1690,7 @@ def test_move_disk_rest(
     assert response.zone == "zone_value"
 
 
-def test_move_disk_rest_bad_request(
+def test_move_disk_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.MoveDiskProjectRequest
 ):
     client = ProjectsClient(
@@ -1713,14 +1713,14 @@ def test_move_disk_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.move_disk(request)
+        client.move_disk_unary(request)
 
 
-def test_move_disk_rest_from_dict():
-    test_move_disk_rest(request_type=dict)
+def test_move_disk_unary_rest_from_dict():
+    test_move_disk_unary_rest(request_type=dict)
 
 
-def test_move_disk_rest_flattened(transport: str = "rest"):
+def test_move_disk_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1749,7 +1749,7 @@ def test_move_disk_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.move_disk(**mock_args)
+        client.move_disk_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1762,7 +1762,7 @@ def test_move_disk_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_move_disk_rest_flattened_error(transport: str = "rest"):
+def test_move_disk_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1770,7 +1770,7 @@ def test_move_disk_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.move_disk(
+        client.move_disk_unary(
             compute.MoveDiskProjectRequest(),
             project="project_value",
             disk_move_request_resource=compute.DiskMoveRequest(
@@ -1779,7 +1779,7 @@ def test_move_disk_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_move_instance_rest(
+def test_move_instance_unary_rest(
     transport: str = "rest", request_type=compute.MoveInstanceProjectRequest
 ):
     client = ProjectsClient(
@@ -1827,7 +1827,7 @@ def test_move_instance_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.move_instance(request)
+        response = client.move_instance_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1855,7 +1855,7 @@ def test_move_instance_rest(
     assert response.zone == "zone_value"
 
 
-def test_move_instance_rest_bad_request(
+def test_move_instance_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.MoveInstanceProjectRequest
 ):
     client = ProjectsClient(
@@ -1878,14 +1878,14 @@ def test_move_instance_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.move_instance(request)
+        client.move_instance_unary(request)
 
 
-def test_move_instance_rest_from_dict():
-    test_move_instance_rest(request_type=dict)
+def test_move_instance_unary_rest_from_dict():
+    test_move_instance_unary_rest(request_type=dict)
 
 
-def test_move_instance_rest_flattened(transport: str = "rest"):
+def test_move_instance_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1914,7 +1914,7 @@ def test_move_instance_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.move_instance(**mock_args)
+        client.move_instance_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1927,7 +1927,7 @@ def test_move_instance_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_move_instance_rest_flattened_error(transport: str = "rest"):
+def test_move_instance_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1935,7 +1935,7 @@ def test_move_instance_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.move_instance(
+        client.move_instance_unary(
             compute.MoveInstanceProjectRequest(),
             project="project_value",
             instance_move_request_resource=compute.InstanceMoveRequest(
@@ -1944,7 +1944,7 @@ def test_move_instance_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_common_instance_metadata_rest(
+def test_set_common_instance_metadata_unary_rest(
     transport: str = "rest",
     request_type=compute.SetCommonInstanceMetadataProjectRequest,
 ):
@@ -1993,7 +1993,7 @@ def test_set_common_instance_metadata_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_common_instance_metadata(request)
+        response = client.set_common_instance_metadata_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2021,7 +2021,7 @@ def test_set_common_instance_metadata_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_common_instance_metadata_rest_bad_request(
+def test_set_common_instance_metadata_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetCommonInstanceMetadataProjectRequest,
 ):
@@ -2045,14 +2045,14 @@ def test_set_common_instance_metadata_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_common_instance_metadata(request)
+        client.set_common_instance_metadata_unary(request)
 
 
-def test_set_common_instance_metadata_rest_from_dict():
-    test_set_common_instance_metadata_rest(request_type=dict)
+def test_set_common_instance_metadata_unary_rest_from_dict():
+    test_set_common_instance_metadata_unary_rest(request_type=dict)
 
 
-def test_set_common_instance_metadata_rest_flattened(transport: str = "rest"):
+def test_set_common_instance_metadata_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2079,7 +2079,7 @@ def test_set_common_instance_metadata_rest_flattened(transport: str = "rest"):
             metadata_resource=compute.Metadata(fingerprint="fingerprint_value"),
         )
         mock_args.update(sample_request)
-        client.set_common_instance_metadata(**mock_args)
+        client.set_common_instance_metadata_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2092,7 +2092,9 @@ def test_set_common_instance_metadata_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_common_instance_metadata_rest_flattened_error(transport: str = "rest"):
+def test_set_common_instance_metadata_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2100,14 +2102,14 @@ def test_set_common_instance_metadata_rest_flattened_error(transport: str = "res
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_common_instance_metadata(
+        client.set_common_instance_metadata_unary(
             compute.SetCommonInstanceMetadataProjectRequest(),
             project="project_value",
             metadata_resource=compute.Metadata(fingerprint="fingerprint_value"),
         )
 
 
-def test_set_default_network_tier_rest(
+def test_set_default_network_tier_unary_rest(
     transport: str = "rest", request_type=compute.SetDefaultNetworkTierProjectRequest
 ):
     client = ProjectsClient(
@@ -2155,7 +2157,7 @@ def test_set_default_network_tier_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_default_network_tier(request)
+        response = client.set_default_network_tier_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2183,7 +2185,7 @@ def test_set_default_network_tier_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_default_network_tier_rest_bad_request(
+def test_set_default_network_tier_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetDefaultNetworkTierProjectRequest
 ):
     client = ProjectsClient(
@@ -2206,14 +2208,14 @@ def test_set_default_network_tier_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_default_network_tier(request)
+        client.set_default_network_tier_unary(request)
 
 
-def test_set_default_network_tier_rest_from_dict():
-    test_set_default_network_tier_rest(request_type=dict)
+def test_set_default_network_tier_unary_rest_from_dict():
+    test_set_default_network_tier_unary_rest(request_type=dict)
 
 
-def test_set_default_network_tier_rest_flattened(transport: str = "rest"):
+def test_set_default_network_tier_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2242,7 +2244,7 @@ def test_set_default_network_tier_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_default_network_tier(**mock_args)
+        client.set_default_network_tier_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2255,7 +2257,7 @@ def test_set_default_network_tier_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_default_network_tier_rest_flattened_error(transport: str = "rest"):
+def test_set_default_network_tier_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2263,7 +2265,7 @@ def test_set_default_network_tier_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_default_network_tier(
+        client.set_default_network_tier_unary(
             compute.SetDefaultNetworkTierProjectRequest(),
             project="project_value",
             projects_set_default_network_tier_request_resource=compute.ProjectsSetDefaultNetworkTierRequest(
@@ -2272,7 +2274,7 @@ def test_set_default_network_tier_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_usage_export_bucket_rest(
+def test_set_usage_export_bucket_unary_rest(
     transport: str = "rest", request_type=compute.SetUsageExportBucketProjectRequest
 ):
     client = ProjectsClient(
@@ -2320,7 +2322,7 @@ def test_set_usage_export_bucket_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_usage_export_bucket(request)
+        response = client.set_usage_export_bucket_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2348,7 +2350,7 @@ def test_set_usage_export_bucket_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_usage_export_bucket_rest_bad_request(
+def test_set_usage_export_bucket_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetUsageExportBucketProjectRequest
 ):
     client = ProjectsClient(
@@ -2371,14 +2373,14 @@ def test_set_usage_export_bucket_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_usage_export_bucket(request)
+        client.set_usage_export_bucket_unary(request)
 
 
-def test_set_usage_export_bucket_rest_from_dict():
-    test_set_usage_export_bucket_rest(request_type=dict)
+def test_set_usage_export_bucket_unary_rest_from_dict():
+    test_set_usage_export_bucket_unary_rest(request_type=dict)
 
 
-def test_set_usage_export_bucket_rest_flattened(transport: str = "rest"):
+def test_set_usage_export_bucket_unary_rest_flattened(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2407,7 +2409,7 @@ def test_set_usage_export_bucket_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_usage_export_bucket(**mock_args)
+        client.set_usage_export_bucket_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2420,7 +2422,7 @@ def test_set_usage_export_bucket_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_usage_export_bucket_rest_flattened_error(transport: str = "rest"):
+def test_set_usage_export_bucket_unary_rest_flattened_error(transport: str = "rest"):
     client = ProjectsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2428,7 +2430,7 @@ def test_set_usage_export_bucket_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_usage_export_bucket(
+        client.set_usage_export_bucket_unary(
             compute.SetUsageExportBucketProjectRequest(),
             project="project_value",
             usage_export_location_resource=compute.UsageExportLocation(

--- a/tests/unit/gapic/compute_v1/test_public_advertised_prefixes.py
+++ b/tests/unit/gapic/compute_v1/test_public_advertised_prefixes.py
@@ -444,7 +444,7 @@ def test_public_advertised_prefixes_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeletePublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -489,7 +489,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -517,7 +517,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeletePublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -537,14 +537,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -571,7 +571,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             public_advertised_prefix="public_advertised_prefix_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -584,7 +584,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -592,7 +592,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeletePublicAdvertisedPrefixeRequest(),
             project="project_value",
             public_advertised_prefix="public_advertised_prefix_value",
@@ -732,7 +732,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertPublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -780,7 +780,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -808,7 +808,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertPublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -831,14 +831,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -867,7 +867,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -880,7 +880,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -888,7 +888,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertPublicAdvertisedPrefixeRequest(),
             project="project_value",
             public_advertised_prefix_resource=compute.PublicAdvertisedPrefix(
@@ -1067,7 +1067,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchPublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -1115,7 +1115,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1143,7 +1143,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchPublicAdvertisedPrefixeRequest
 ):
     client = PublicAdvertisedPrefixesClient(
@@ -1166,14 +1166,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1203,7 +1203,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1216,7 +1216,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicAdvertisedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1224,7 +1224,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchPublicAdvertisedPrefixeRequest(),
             project="project_value",
             public_advertised_prefix="public_advertised_prefix_value",

--- a/tests/unit/gapic/compute_v1/test_public_delegated_prefixes.py
+++ b/tests/unit/gapic/compute_v1/test_public_delegated_prefixes.py
@@ -634,7 +634,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeletePublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -683,7 +683,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -711,7 +711,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeletePublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -735,14 +735,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -774,7 +774,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             public_delegated_prefix="public_delegated_prefix_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -787,7 +787,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -795,7 +795,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeletePublicDelegatedPrefixeRequest(),
             project="project_value",
             region="region_value",
@@ -952,7 +952,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertPublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -1000,7 +1000,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1028,7 +1028,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertPublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -1051,14 +1051,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1088,7 +1088,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1101,7 +1101,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1109,7 +1109,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertPublicDelegatedPrefixeRequest(),
             project="project_value",
             region="region_value",
@@ -1289,7 +1289,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchPublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -1341,7 +1341,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1369,7 +1369,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchPublicDelegatedPrefixeRequest
 ):
     client = PublicDelegatedPrefixesClient(
@@ -1396,14 +1396,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1438,7 +1438,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1451,7 +1451,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = PublicDelegatedPrefixesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1459,7 +1459,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchPublicDelegatedPrefixeRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_autoscalers.py
+++ b/tests/unit/gapic/compute_v1/test_region_autoscalers.py
@@ -420,7 +420,7 @@ def test_region_autoscalers_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -465,7 +465,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -493,7 +493,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -513,14 +513,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -552,7 +552,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             autoscaler="autoscaler_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -565,7 +565,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -573,7 +573,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionAutoscalerRequest(),
             project="project_value",
             region="region_value",
@@ -720,7 +720,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -768,7 +768,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -796,7 +796,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -819,14 +819,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -856,7 +856,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -869,7 +869,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -877,7 +877,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionAutoscalerRequest(),
             project="project_value",
             region="region_value",
@@ -1052,7 +1052,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -1100,7 +1100,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1128,7 +1128,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -1151,14 +1151,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1188,7 +1188,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1201,7 +1201,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1209,7 +1209,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionAutoscalerRequest(),
             project="project_value",
             region="region_value",
@@ -1219,7 +1219,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -1267,7 +1267,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1295,7 +1295,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateRegionAutoscalerRequest
 ):
     client = RegionAutoscalersClient(
@@ -1318,14 +1318,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1355,7 +1355,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1368,7 +1368,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionAutoscalersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1376,7 +1376,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateRegionAutoscalerRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_backend_services.py
+++ b/tests/unit/gapic/compute_v1/test_region_backend_services.py
@@ -440,7 +440,7 @@ def test_region_backend_services_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -489,7 +489,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -517,7 +517,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -541,14 +541,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -580,7 +580,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             backend_service="backend_service_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -593,7 +593,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -601,7 +601,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionBackendServiceRequest(),
             project="project_value",
             region="region_value",
@@ -915,7 +915,7 @@ def test_get_health_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -963,7 +963,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -991,7 +991,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -1014,14 +1014,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1051,7 +1051,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1064,7 +1064,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1072,7 +1072,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionBackendServiceRequest(),
             project="project_value",
             region="region_value",
@@ -1249,7 +1249,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -1301,7 +1301,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1329,7 +1329,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -1356,14 +1356,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1398,7 +1398,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1411,7 +1411,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1419,7 +1419,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionBackendServiceRequest(),
             project="project_value",
             region="region_value",
@@ -1430,7 +1430,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -1482,7 +1482,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1510,7 +1510,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateRegionBackendServiceRequest
 ):
     client = RegionBackendServicesClient(
@@ -1537,14 +1537,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1579,7 +1579,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1592,7 +1592,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionBackendServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1600,7 +1600,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateRegionBackendServiceRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_commitments.py
+++ b/tests/unit/gapic/compute_v1/test_region_commitments.py
@@ -745,7 +745,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionCommitmentRequest
 ):
     client = RegionCommitmentsClient(
@@ -791,7 +791,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -819,7 +819,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionCommitmentRequest
 ):
     client = RegionCommitmentsClient(
@@ -840,14 +840,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionCommitmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -875,7 +875,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             commitment_resource=compute.Commitment(category="category_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -888,7 +888,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionCommitmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -896,7 +896,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionCommitmentRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_disks.py
+++ b/tests/unit/gapic/compute_v1/test_region_disks.py
@@ -401,7 +401,7 @@ def test_region_disks_client_client_options_credentials_file(
         )
 
 
-def test_add_resource_policies_rest(
+def test_add_resource_policies_unary_rest(
     transport: str = "rest", request_type=compute.AddResourcePoliciesRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -451,7 +451,7 @@ def test_add_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_resource_policies(request)
+        response = client.add_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -479,7 +479,7 @@ def test_add_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_resource_policies_rest_bad_request(
+def test_add_resource_policies_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddResourcePoliciesRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -504,14 +504,14 @@ def test_add_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_resource_policies(request)
+        client.add_resource_policies_unary(request)
 
 
-def test_add_resource_policies_rest_from_dict():
-    test_add_resource_policies_rest(request_type=dict)
+def test_add_resource_policies_unary_rest_from_dict():
+    test_add_resource_policies_unary_rest(request_type=dict)
 
 
-def test_add_resource_policies_rest_flattened(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,7 +542,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_resource_policies(**mock_args)
+        client.add_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -555,7 +555,7 @@ def test_add_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_add_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -563,7 +563,7 @@ def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_resource_policies(
+        client.add_resource_policies_unary(
             compute.AddResourcePoliciesRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -574,7 +574,7 @@ def test_add_resource_policies_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_create_snapshot_rest(
+def test_create_snapshot_unary_rest(
     transport: str = "rest", request_type=compute.CreateSnapshotRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -620,7 +620,7 @@ def test_create_snapshot_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.create_snapshot(request)
+        response = client.create_snapshot_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -648,7 +648,7 @@ def test_create_snapshot_rest(
     assert response.zone == "zone_value"
 
 
-def test_create_snapshot_rest_bad_request(
+def test_create_snapshot_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.CreateSnapshotRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -669,14 +669,14 @@ def test_create_snapshot_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.create_snapshot(request)
+        client.create_snapshot_unary(request)
 
 
-def test_create_snapshot_rest_from_dict():
-    test_create_snapshot_rest(request_type=dict)
+def test_create_snapshot_unary_rest_from_dict():
+    test_create_snapshot_unary_rest(request_type=dict)
 
 
-def test_create_snapshot_rest_flattened(transport: str = "rest"):
+def test_create_snapshot_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -705,7 +705,7 @@ def test_create_snapshot_rest_flattened(transport: str = "rest"):
             snapshot_resource=compute.Snapshot(auto_created=True),
         )
         mock_args.update(sample_request)
-        client.create_snapshot(**mock_args)
+        client.create_snapshot_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -718,7 +718,7 @@ def test_create_snapshot_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
+def test_create_snapshot_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -726,7 +726,7 @@ def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.create_snapshot(
+        client.create_snapshot_unary(
             compute.CreateSnapshotRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -735,7 +735,7 @@ def test_create_snapshot_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -780,7 +780,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -808,7 +808,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -828,14 +828,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -861,7 +861,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", region="region_value", disk="disk_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -874,7 +874,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -882,7 +882,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -1178,7 +1178,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -1226,7 +1226,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1254,7 +1254,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -1277,14 +1277,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1312,7 +1312,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             disk_resource=compute.Disk(creation_timestamp="creation_timestamp_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1325,7 +1325,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1333,7 +1333,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -1498,7 +1498,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_remove_resource_policies_rest(
+def test_remove_resource_policies_unary_rest(
     transport: str = "rest",
     request_type=compute.RemoveResourcePoliciesRegionDiskRequest,
 ):
@@ -1549,7 +1549,7 @@ def test_remove_resource_policies_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_resource_policies(request)
+        response = client.remove_resource_policies_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1577,7 +1577,7 @@ def test_remove_resource_policies_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_resource_policies_rest_bad_request(
+def test_remove_resource_policies_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.RemoveResourcePoliciesRegionDiskRequest,
 ):
@@ -1603,14 +1603,14 @@ def test_remove_resource_policies_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_resource_policies(request)
+        client.remove_resource_policies_unary(request)
 
 
-def test_remove_resource_policies_rest_from_dict():
-    test_remove_resource_policies_rest(request_type=dict)
+def test_remove_resource_policies_unary_rest_from_dict():
+    test_remove_resource_policies_unary_rest(request_type=dict)
 
 
-def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1641,7 +1641,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_resource_policies(**mock_args)
+        client.remove_resource_policies_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1654,7 +1654,7 @@ def test_remove_resource_policies_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
+def test_remove_resource_policies_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1662,7 +1662,7 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_resource_policies(
+        client.remove_resource_policies_unary(
             compute.RemoveResourcePoliciesRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -1673,7 +1673,7 @@ def test_remove_resource_policies_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_resize_rest(
+def test_resize_unary_rest(
     transport: str = "rest", request_type=compute.ResizeRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -1721,7 +1721,7 @@ def test_resize_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.resize(request)
+        response = client.resize_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1749,7 +1749,7 @@ def test_resize_rest(
     assert response.zone == "zone_value"
 
 
-def test_resize_rest_bad_request(
+def test_resize_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ResizeRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -1772,14 +1772,14 @@ def test_resize_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.resize(request)
+        client.resize_unary(request)
 
 
-def test_resize_rest_from_dict():
-    test_resize_rest(request_type=dict)
+def test_resize_unary_rest_from_dict():
+    test_resize_unary_rest(request_type=dict)
 
 
-def test_resize_rest_flattened(transport: str = "rest"):
+def test_resize_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1810,7 +1810,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.resize(**mock_args)
+        client.resize_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1823,7 +1823,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_resize_rest_flattened_error(transport: str = "rest"):
+def test_resize_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1831,7 +1831,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.resize(
+        client.resize_unary(
             compute.ResizeRegionDiskRequest(),
             project="project_value",
             region="region_value",
@@ -1973,7 +1973,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -2021,7 +2021,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2049,7 +2049,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsRegionDiskRequest
 ):
     client = RegionDisksClient(
@@ -2072,14 +2072,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2114,7 +2114,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2127,7 +2127,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionDisksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2135,7 +2135,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsRegionDiskRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_health_check_services.py
+++ b/tests/unit/gapic/compute_v1/test_region_health_check_services.py
@@ -446,7 +446,7 @@ def test_region_health_check_services_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -495,7 +495,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -523,7 +523,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -547,14 +547,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -586,7 +586,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             health_check_service="health_check_service_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -599,7 +599,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -607,7 +607,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionHealthCheckServiceRequest(),
             project="project_value",
             region="region_value",
@@ -767,7 +767,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -815,7 +815,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -843,7 +843,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -866,14 +866,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -903,7 +903,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -916,7 +916,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -924,7 +924,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionHealthCheckServiceRequest(),
             project="project_value",
             region="region_value",
@@ -1101,7 +1101,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -1153,7 +1153,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1181,7 +1181,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionHealthCheckServiceRequest
 ):
     client = RegionHealthCheckServicesClient(
@@ -1208,14 +1208,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1250,7 +1250,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1263,7 +1263,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthCheckServicesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1271,7 +1271,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionHealthCheckServiceRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_health_checks.py
+++ b/tests/unit/gapic/compute_v1/test_region_health_checks.py
@@ -422,7 +422,7 @@ def test_region_health_checks_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -471,7 +471,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -499,7 +499,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -523,14 +523,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -562,7 +562,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             health_check="health_check_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -575,7 +575,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -583,7 +583,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionHealthCheckRequest(),
             project="project_value",
             region="region_value",
@@ -740,7 +740,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -786,7 +786,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -814,7 +814,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -835,14 +835,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -870,7 +870,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -883,7 +883,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -891,7 +891,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionHealthCheckRequest(),
             project="project_value",
             region="region_value",
@@ -1066,7 +1066,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -1116,7 +1116,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1144,7 +1144,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -1169,14 +1169,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1209,7 +1209,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1222,7 +1222,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1230,7 +1230,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionHealthCheckRequest(),
             project="project_value",
             region="region_value",
@@ -1239,7 +1239,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -1289,7 +1289,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1317,7 +1317,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateRegionHealthCheckRequest
 ):
     client = RegionHealthChecksClient(
@@ -1342,14 +1342,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1382,7 +1382,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             health_check_resource=compute.HealthCheck(check_interval_sec=1884),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1395,7 +1395,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionHealthChecksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1403,7 +1403,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateRegionHealthCheckRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_instance_group_managers.py
+++ b/tests/unit/gapic/compute_v1/test_region_instance_group_managers.py
@@ -446,7 +446,7 @@ def test_region_instance_group_managers_client_client_options_credentials_file(
         )
 
 
-def test_abandon_instances_rest(
+def test_abandon_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.AbandonInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -501,7 +501,7 @@ def test_abandon_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.abandon_instances(request)
+        response = client.abandon_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -529,7 +529,7 @@ def test_abandon_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_abandon_instances_rest_bad_request(
+def test_abandon_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.AbandonInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -559,14 +559,14 @@ def test_abandon_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.abandon_instances(request)
+        client.abandon_instances_unary(request)
 
 
-def test_abandon_instances_rest_from_dict():
-    test_abandon_instances_rest(request_type=dict)
+def test_abandon_instances_unary_rest_from_dict():
+    test_abandon_instances_unary_rest(request_type=dict)
 
 
-def test_abandon_instances_rest_flattened(transport: str = "rest"):
+def test_abandon_instances_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -601,7 +601,7 @@ def test_abandon_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.abandon_instances(**mock_args)
+        client.abandon_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -614,7 +614,7 @@ def test_abandon_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_abandon_instances_rest_flattened_error(transport: str = "rest"):
+def test_abandon_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -622,7 +622,7 @@ def test_abandon_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.abandon_instances(
+        client.abandon_instances_unary(
             compute.AbandonInstancesRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -633,7 +633,7 @@ def test_abandon_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_apply_updates_to_instances_rest(
+def test_apply_updates_to_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.ApplyUpdatesToInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -686,7 +686,7 @@ def test_apply_updates_to_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.apply_updates_to_instances(request)
+        response = client.apply_updates_to_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -714,7 +714,7 @@ def test_apply_updates_to_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_apply_updates_to_instances_rest_bad_request(
+def test_apply_updates_to_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.ApplyUpdatesToInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -742,14 +742,14 @@ def test_apply_updates_to_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.apply_updates_to_instances(request)
+        client.apply_updates_to_instances_unary(request)
 
 
-def test_apply_updates_to_instances_rest_from_dict():
-    test_apply_updates_to_instances_rest(request_type=dict)
+def test_apply_updates_to_instances_unary_rest_from_dict():
+    test_apply_updates_to_instances_unary_rest(request_type=dict)
 
 
-def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
+def test_apply_updates_to_instances_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -784,7 +784,7 @@ def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.apply_updates_to_instances(**mock_args)
+        client.apply_updates_to_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -797,7 +797,7 @@ def test_apply_updates_to_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"):
+def test_apply_updates_to_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -805,7 +805,7 @@ def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.apply_updates_to_instances(
+        client.apply_updates_to_instances_unary(
             compute.ApplyUpdatesToInstancesRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -816,7 +816,7 @@ def test_apply_updates_to_instances_rest_flattened_error(transport: str = "rest"
         )
 
 
-def test_create_instances_rest(
+def test_create_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.CreateInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -871,7 +871,7 @@ def test_create_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.create_instances(request)
+        response = client.create_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -899,7 +899,7 @@ def test_create_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_create_instances_rest_bad_request(
+def test_create_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.CreateInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -929,14 +929,14 @@ def test_create_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.create_instances(request)
+        client.create_instances_unary(request)
 
 
-def test_create_instances_rest_from_dict():
-    test_create_instances_rest(request_type=dict)
+def test_create_instances_unary_rest_from_dict():
+    test_create_instances_unary_rest(request_type=dict)
 
 
-def test_create_instances_rest_flattened(transport: str = "rest"):
+def test_create_instances_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -971,7 +971,7 @@ def test_create_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.create_instances(**mock_args)
+        client.create_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -984,7 +984,7 @@ def test_create_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_create_instances_rest_flattened_error(transport: str = "rest"):
+def test_create_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -992,7 +992,7 @@ def test_create_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.create_instances(
+        client.create_instances_unary(
             compute.CreateInstancesRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -1003,7 +1003,7 @@ def test_create_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteRegionInstanceGroupManagerRequest,
 ):
@@ -1053,7 +1053,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1081,7 +1081,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteRegionInstanceGroupManagerRequest,
 ):
@@ -1106,14 +1106,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1145,7 +1145,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             instance_group_manager="instance_group_manager_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1158,7 +1158,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1166,7 +1166,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -1174,7 +1174,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_instances_rest(
+def test_delete_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -1229,7 +1229,7 @@ def test_delete_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_instances(request)
+        response = client.delete_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1257,7 +1257,7 @@ def test_delete_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_instances_rest_bad_request(
+def test_delete_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -1287,14 +1287,14 @@ def test_delete_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_instances(request)
+        client.delete_instances_unary(request)
 
 
-def test_delete_instances_rest_from_dict():
-    test_delete_instances_rest(request_type=dict)
+def test_delete_instances_unary_rest_from_dict():
+    test_delete_instances_unary_rest(request_type=dict)
 
 
-def test_delete_instances_rest_flattened(transport: str = "rest"):
+def test_delete_instances_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1329,7 +1329,7 @@ def test_delete_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.delete_instances(**mock_args)
+        client.delete_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1342,7 +1342,7 @@ def test_delete_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_instances_rest_flattened_error(transport: str = "rest"):
+def test_delete_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1350,7 +1350,7 @@ def test_delete_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_instances(
+        client.delete_instances_unary(
             compute.DeleteInstancesRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -1361,7 +1361,7 @@ def test_delete_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_per_instance_configs_rest(
+def test_delete_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.DeletePerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -1414,7 +1414,7 @@ def test_delete_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete_per_instance_configs(request)
+        response = client.delete_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1442,7 +1442,7 @@ def test_delete_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_per_instance_configs_rest_bad_request(
+def test_delete_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeletePerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -1470,14 +1470,14 @@ def test_delete_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete_per_instance_configs(request)
+        client.delete_per_instance_configs_unary(request)
 
 
-def test_delete_per_instance_configs_rest_from_dict():
-    test_delete_per_instance_configs_rest(request_type=dict)
+def test_delete_per_instance_configs_unary_rest_from_dict():
+    test_delete_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_delete_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1512,7 +1512,7 @@ def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.delete_per_instance_configs(**mock_args)
+        client.delete_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1525,7 +1525,9 @@ def test_delete_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_delete_per_instance_configs_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1533,7 +1535,7 @@ def test_delete_per_instance_configs_rest_flattened_error(transport: str = "rest
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete_per_instance_configs(
+        client.delete_per_instance_configs_unary(
             compute.DeletePerInstanceConfigsRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -1697,7 +1699,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest",
     request_type=compute.InsertRegionInstanceGroupManagerRequest,
 ):
@@ -1750,7 +1752,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1778,7 +1780,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.InsertRegionInstanceGroupManagerRequest,
 ):
@@ -1806,14 +1808,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1847,7 +1849,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1860,7 +1862,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1868,7 +1870,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -2636,7 +2638,7 @@ def test_list_per_instance_configs_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionInstanceGroupManagerRequest
 ):
     client = RegionInstanceGroupManagersClient(
@@ -2692,7 +2694,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2720,7 +2722,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionInstanceGroupManagerRequest
 ):
     client = RegionInstanceGroupManagersClient(
@@ -2751,14 +2753,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2797,7 +2799,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2810,7 +2812,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2818,7 +2820,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -2833,7 +2835,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_patch_per_instance_configs_rest(
+def test_patch_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.PatchPerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -2890,7 +2892,7 @@ def test_patch_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch_per_instance_configs(request)
+        response = client.patch_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2918,7 +2920,7 @@ def test_patch_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_per_instance_configs_rest_bad_request(
+def test_patch_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.PatchPerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -2950,14 +2952,14 @@ def test_patch_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch_per_instance_configs(request)
+        client.patch_per_instance_configs_unary(request)
 
 
-def test_patch_per_instance_configs_rest_from_dict():
-    test_patch_per_instance_configs_rest(request_type=dict)
+def test_patch_per_instance_configs_unary_rest_from_dict():
+    test_patch_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_patch_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2994,7 +2996,7 @@ def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch_per_instance_configs(**mock_args)
+        client.patch_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3007,7 +3009,7 @@ def test_patch_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_patch_per_instance_configs_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3015,7 +3017,7 @@ def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch_per_instance_configs(
+        client.patch_per_instance_configs_unary(
             compute.PatchPerInstanceConfigsRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -3028,7 +3030,7 @@ def test_patch_per_instance_configs_rest_flattened_error(transport: str = "rest"
         )
 
 
-def test_recreate_instances_rest(
+def test_recreate_instances_unary_rest(
     transport: str = "rest",
     request_type=compute.RecreateInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -3083,7 +3085,7 @@ def test_recreate_instances_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.recreate_instances(request)
+        response = client.recreate_instances_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3111,7 +3113,7 @@ def test_recreate_instances_rest(
     assert response.zone == "zone_value"
 
 
-def test_recreate_instances_rest_bad_request(
+def test_recreate_instances_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.RecreateInstancesRegionInstanceGroupManagerRequest,
 ):
@@ -3141,14 +3143,14 @@ def test_recreate_instances_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.recreate_instances(request)
+        client.recreate_instances_unary(request)
 
 
-def test_recreate_instances_rest_from_dict():
-    test_recreate_instances_rest(request_type=dict)
+def test_recreate_instances_unary_rest_from_dict():
+    test_recreate_instances_unary_rest(request_type=dict)
 
 
-def test_recreate_instances_rest_flattened(transport: str = "rest"):
+def test_recreate_instances_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3183,7 +3185,7 @@ def test_recreate_instances_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.recreate_instances(**mock_args)
+        client.recreate_instances_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3196,7 +3198,7 @@ def test_recreate_instances_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
+def test_recreate_instances_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3204,7 +3206,7 @@ def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.recreate_instances(
+        client.recreate_instances_unary(
             compute.RecreateInstancesRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -3215,7 +3217,7 @@ def test_recreate_instances_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_resize_rest(
+def test_resize_unary_rest(
     transport: str = "rest",
     request_type=compute.ResizeRegionInstanceGroupManagerRequest,
 ):
@@ -3265,7 +3267,7 @@ def test_resize_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.resize(request)
+        response = client.resize_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3293,7 +3295,7 @@ def test_resize_rest(
     assert response.zone == "zone_value"
 
 
-def test_resize_rest_bad_request(
+def test_resize_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.ResizeRegionInstanceGroupManagerRequest,
 ):
@@ -3318,14 +3320,14 @@ def test_resize_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.resize(request)
+        client.resize_unary(request)
 
 
-def test_resize_rest_from_dict():
-    test_resize_rest(request_type=dict)
+def test_resize_unary_rest_from_dict():
+    test_resize_unary_rest(request_type=dict)
 
 
-def test_resize_rest_flattened(transport: str = "rest"):
+def test_resize_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3358,7 +3360,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
             size=443,
         )
         mock_args.update(sample_request)
-        client.resize(**mock_args)
+        client.resize_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3371,7 +3373,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_resize_rest_flattened_error(transport: str = "rest"):
+def test_resize_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3379,7 +3381,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.resize(
+        client.resize_unary(
             compute.ResizeRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -3388,7 +3390,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_instance_template_rest(
+def test_set_instance_template_unary_rest(
     transport: str = "rest",
     request_type=compute.SetInstanceTemplateRegionInstanceGroupManagerRequest,
 ):
@@ -3443,7 +3445,7 @@ def test_set_instance_template_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_instance_template(request)
+        response = client.set_instance_template_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3471,7 +3473,7 @@ def test_set_instance_template_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_instance_template_rest_bad_request(
+def test_set_instance_template_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetInstanceTemplateRegionInstanceGroupManagerRequest,
 ):
@@ -3501,14 +3503,14 @@ def test_set_instance_template_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_instance_template(request)
+        client.set_instance_template_unary(request)
 
 
-def test_set_instance_template_rest_from_dict():
-    test_set_instance_template_rest(request_type=dict)
+def test_set_instance_template_unary_rest_from_dict():
+    test_set_instance_template_unary_rest(request_type=dict)
 
 
-def test_set_instance_template_rest_flattened(transport: str = "rest"):
+def test_set_instance_template_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3543,7 +3545,7 @@ def test_set_instance_template_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_instance_template(**mock_args)
+        client.set_instance_template_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3556,7 +3558,7 @@ def test_set_instance_template_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
+def test_set_instance_template_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3564,7 +3566,7 @@ def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_instance_template(
+        client.set_instance_template_unary(
             compute.SetInstanceTemplateRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -3575,7 +3577,7 @@ def test_set_instance_template_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_target_pools_rest(
+def test_set_target_pools_unary_rest(
     transport: str = "rest",
     request_type=compute.SetTargetPoolsRegionInstanceGroupManagerRequest,
 ):
@@ -3630,7 +3632,7 @@ def test_set_target_pools_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_target_pools(request)
+        response = client.set_target_pools_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3658,7 +3660,7 @@ def test_set_target_pools_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_target_pools_rest_bad_request(
+def test_set_target_pools_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetTargetPoolsRegionInstanceGroupManagerRequest,
 ):
@@ -3688,14 +3690,14 @@ def test_set_target_pools_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_target_pools(request)
+        client.set_target_pools_unary(request)
 
 
-def test_set_target_pools_rest_from_dict():
-    test_set_target_pools_rest(request_type=dict)
+def test_set_target_pools_unary_rest_from_dict():
+    test_set_target_pools_unary_rest(request_type=dict)
 
 
-def test_set_target_pools_rest_flattened(transport: str = "rest"):
+def test_set_target_pools_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3730,7 +3732,7 @@ def test_set_target_pools_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_target_pools(**mock_args)
+        client.set_target_pools_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3743,7 +3745,7 @@ def test_set_target_pools_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
+def test_set_target_pools_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3751,7 +3753,7 @@ def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_target_pools(
+        client.set_target_pools_unary(
             compute.SetTargetPoolsRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",
@@ -3762,7 +3764,7 @@ def test_set_target_pools_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_per_instance_configs_rest(
+def test_update_per_instance_configs_unary_rest(
     transport: str = "rest",
     request_type=compute.UpdatePerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -3819,7 +3821,7 @@ def test_update_per_instance_configs_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update_per_instance_configs(request)
+        response = client.update_per_instance_configs_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -3847,7 +3849,7 @@ def test_update_per_instance_configs_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_per_instance_configs_rest_bad_request(
+def test_update_per_instance_configs_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.UpdatePerInstanceConfigsRegionInstanceGroupManagerRequest,
 ):
@@ -3879,14 +3881,14 @@ def test_update_per_instance_configs_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update_per_instance_configs(request)
+        client.update_per_instance_configs_unary(request)
 
 
-def test_update_per_instance_configs_rest_from_dict():
-    test_update_per_instance_configs_rest(request_type=dict)
+def test_update_per_instance_configs_unary_rest_from_dict():
+    test_update_per_instance_configs_unary_rest(request_type=dict)
 
 
-def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
+def test_update_per_instance_configs_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3923,7 +3925,7 @@ def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update_per_instance_configs(**mock_args)
+        client.update_per_instance_configs_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -3936,7 +3938,9 @@ def test_update_per_instance_configs_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_per_instance_configs_rest_flattened_error(transport: str = "rest"):
+def test_update_per_instance_configs_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = RegionInstanceGroupManagersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -3944,7 +3948,7 @@ def test_update_per_instance_configs_rest_flattened_error(transport: str = "rest
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update_per_instance_configs(
+        client.update_per_instance_configs_unary(
             compute.UpdatePerInstanceConfigsRegionInstanceGroupManagerRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_instance_groups.py
+++ b/tests/unit/gapic/compute_v1/test_region_instance_groups.py
@@ -976,7 +976,7 @@ def test_list_instances_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_named_ports_rest(
+def test_set_named_ports_unary_rest(
     transport: str = "rest",
     request_type=compute.SetNamedPortsRegionInstanceGroupRequest,
 ):
@@ -1031,7 +1031,7 @@ def test_set_named_ports_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_named_ports(request)
+        response = client.set_named_ports_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1059,7 +1059,7 @@ def test_set_named_ports_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_named_ports_rest_bad_request(
+def test_set_named_ports_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetNamedPortsRegionInstanceGroupRequest,
 ):
@@ -1089,14 +1089,14 @@ def test_set_named_ports_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_named_ports(request)
+        client.set_named_ports_unary(request)
 
 
-def test_set_named_ports_rest_from_dict():
-    test_set_named_ports_rest(request_type=dict)
+def test_set_named_ports_unary_rest_from_dict():
+    test_set_named_ports_unary_rest(request_type=dict)
 
 
-def test_set_named_ports_rest_flattened(transport: str = "rest"):
+def test_set_named_ports_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1131,7 +1131,7 @@ def test_set_named_ports_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_named_ports(**mock_args)
+        client.set_named_ports_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1144,7 +1144,7 @@ def test_set_named_ports_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_named_ports_rest_flattened_error(transport: str = "rest"):
+def test_set_named_ports_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstanceGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1152,7 +1152,7 @@ def test_set_named_ports_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_named_ports(
+        client.set_named_ports_unary(
             compute.SetNamedPortsRegionInstanceGroupRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_instances.py
+++ b/tests/unit/gapic/compute_v1/test_region_instances.py
@@ -418,7 +418,7 @@ def test_region_instances_client_client_options_credentials_file(
         )
 
 
-def test_bulk_insert_rest(
+def test_bulk_insert_unary_rest(
     transport: str = "rest", request_type=compute.BulkInsertRegionInstanceRequest
 ):
     client = RegionInstancesClient(
@@ -466,7 +466,7 @@ def test_bulk_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.bulk_insert(request)
+        response = client.bulk_insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -494,7 +494,7 @@ def test_bulk_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_bulk_insert_rest_bad_request(
+def test_bulk_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.BulkInsertRegionInstanceRequest
 ):
     client = RegionInstancesClient(
@@ -517,14 +517,14 @@ def test_bulk_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.bulk_insert(request)
+        client.bulk_insert_unary(request)
 
 
-def test_bulk_insert_rest_from_dict():
-    test_bulk_insert_rest(request_type=dict)
+def test_bulk_insert_unary_rest_from_dict():
+    test_bulk_insert_unary_rest(request_type=dict)
 
 
-def test_bulk_insert_rest_flattened(transport: str = "rest"):
+def test_bulk_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -554,7 +554,7 @@ def test_bulk_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.bulk_insert(**mock_args)
+        client.bulk_insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -567,7 +567,7 @@ def test_bulk_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_bulk_insert_rest_flattened_error(transport: str = "rest"):
+def test_bulk_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -575,7 +575,7 @@ def test_bulk_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.bulk_insert(
+        client.bulk_insert_unary(
             compute.BulkInsertRegionInstanceRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_network_endpoint_groups.py
+++ b/tests/unit/gapic/compute_v1/test_region_network_endpoint_groups.py
@@ -446,7 +446,7 @@ def test_region_network_endpoint_groups_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteRegionNetworkEndpointGroupRequest,
 ):
@@ -496,7 +496,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -524,7 +524,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteRegionNetworkEndpointGroupRequest,
 ):
@@ -549,14 +549,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -588,7 +588,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             network_endpoint_group="network_endpoint_group_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -601,7 +601,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -609,7 +609,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionNetworkEndpointGroupRequest(),
             project="project_value",
             region="region_value",
@@ -768,7 +768,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest",
     request_type=compute.InsertRegionNetworkEndpointGroupRequest,
 ):
@@ -817,7 +817,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -845,7 +845,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.InsertRegionNetworkEndpointGroupRequest,
 ):
@@ -869,14 +869,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -906,7 +906,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -919,7 +919,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionNetworkEndpointGroupsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -927,7 +927,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionNetworkEndpointGroupRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_notification_endpoints.py
+++ b/tests/unit/gapic/compute_v1/test_region_notification_endpoints.py
@@ -446,7 +446,7 @@ def test_region_notification_endpoints_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest",
     request_type=compute.DeleteRegionNotificationEndpointRequest,
 ):
@@ -496,7 +496,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -524,7 +524,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.DeleteRegionNotificationEndpointRequest,
 ):
@@ -549,14 +549,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionNotificationEndpointsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -588,7 +588,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             notification_endpoint="notification_endpoint_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -601,7 +601,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionNotificationEndpointsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -609,7 +609,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionNotificationEndpointRequest(),
             project="project_value",
             region="region_value",
@@ -756,7 +756,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest",
     request_type=compute.InsertRegionNotificationEndpointRequest,
 ):
@@ -805,7 +805,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -833,7 +833,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.InsertRegionNotificationEndpointRequest,
 ):
@@ -857,14 +857,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionNotificationEndpointsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -894,7 +894,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -907,7 +907,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionNotificationEndpointsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -915,7 +915,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionNotificationEndpointRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_ssl_certificates.py
+++ b/tests/unit/gapic/compute_v1/test_region_ssl_certificates.py
@@ -440,7 +440,7 @@ def test_region_ssl_certificates_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionSslCertificateRequest
 ):
     client = RegionSslCertificatesClient(
@@ -489,7 +489,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -517,7 +517,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionSslCertificateRequest
 ):
     client = RegionSslCertificatesClient(
@@ -541,14 +541,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionSslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -580,7 +580,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             ssl_certificate="ssl_certificate_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -593,7 +593,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionSslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -601,7 +601,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionSslCertificateRequest(),
             project="project_value",
             region="region_value",
@@ -758,7 +758,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionSslCertificateRequest
 ):
     client = RegionSslCertificatesClient(
@@ -806,7 +806,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -834,7 +834,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionSslCertificateRequest
 ):
     client = RegionSslCertificatesClient(
@@ -857,14 +857,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionSslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -894,7 +894,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -907,7 +907,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionSslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -915,7 +915,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionSslCertificateRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_target_http_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_region_target_http_proxies.py
@@ -440,7 +440,7 @@ def test_region_target_http_proxies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -489,7 +489,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -517,7 +517,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -541,14 +541,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -580,7 +580,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             target_http_proxy="target_http_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -593,7 +593,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -601,7 +601,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionTargetHttpProxyRequest(),
             project="project_value",
             region="region_value",
@@ -754,7 +754,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -802,7 +802,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -830,7 +830,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -853,14 +853,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -890,7 +890,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -903,7 +903,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -911,7 +911,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionTargetHttpProxyRequest(),
             project="project_value",
             region="region_value",
@@ -1088,7 +1088,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_url_map_rest(
+def test_set_url_map_unary_rest(
     transport: str = "rest", request_type=compute.SetUrlMapRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -1140,7 +1140,7 @@ def test_set_url_map_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_url_map(request)
+        response = client.set_url_map_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1168,7 +1168,7 @@ def test_set_url_map_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_url_map_rest_bad_request(
+def test_set_url_map_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetUrlMapRegionTargetHttpProxyRequest
 ):
     client = RegionTargetHttpProxiesClient(
@@ -1195,14 +1195,14 @@ def test_set_url_map_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_url_map(request)
+        client.set_url_map_unary(request)
 
 
-def test_set_url_map_rest_from_dict():
-    test_set_url_map_rest(request_type=dict)
+def test_set_url_map_unary_rest_from_dict():
+    test_set_url_map_unary_rest(request_type=dict)
 
 
-def test_set_url_map_rest_flattened(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1235,7 +1235,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
             url_map_reference_resource=compute.UrlMapReference(url_map="url_map_value"),
         )
         mock_args.update(sample_request)
-        client.set_url_map(**mock_args)
+        client.set_url_map_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1248,7 +1248,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest_flattened_error(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1256,7 +1256,7 @@ def test_set_url_map_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_url_map(
+        client.set_url_map_unary(
             compute.SetUrlMapRegionTargetHttpProxyRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_target_https_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_region_target_https_proxies.py
@@ -444,7 +444,7 @@ def test_region_target_https_proxies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -493,7 +493,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -521,7 +521,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -545,14 +545,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -584,7 +584,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             target_https_proxy="target_https_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -597,7 +597,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -605,7 +605,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionTargetHttpsProxyRequest(),
             project="project_value",
             region="region_value",
@@ -768,7 +768,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -816,7 +816,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -844,7 +844,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -867,14 +867,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -904,7 +904,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -917,7 +917,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -925,7 +925,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionTargetHttpsProxyRequest(),
             project="project_value",
             region="region_value",
@@ -1102,7 +1102,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_ssl_certificates_rest(
+def test_set_ssl_certificates_unary_rest(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesRegionTargetHttpsProxyRequest,
 ):
@@ -1157,7 +1157,7 @@ def test_set_ssl_certificates_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_ssl_certificates(request)
+        response = client.set_ssl_certificates_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1185,7 +1185,7 @@ def test_set_ssl_certificates_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_ssl_certificates_rest_bad_request(
+def test_set_ssl_certificates_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesRegionTargetHttpsProxyRequest,
 ):
@@ -1215,14 +1215,14 @@ def test_set_ssl_certificates_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_ssl_certificates(request)
+        client.set_ssl_certificates_unary(request)
 
 
-def test_set_ssl_certificates_rest_from_dict():
-    test_set_ssl_certificates_rest(request_type=dict)
+def test_set_ssl_certificates_unary_rest_from_dict():
+    test_set_ssl_certificates_unary_rest(request_type=dict)
 
 
-def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1257,7 +1257,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_ssl_certificates(**mock_args)
+        client.set_ssl_certificates_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1270,7 +1270,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1278,7 +1278,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_ssl_certificates(
+        client.set_ssl_certificates_unary(
             compute.SetSslCertificatesRegionTargetHttpsProxyRequest(),
             project="project_value",
             region="region_value",
@@ -1289,7 +1289,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest(
+def test_set_url_map_unary_rest(
     transport: str = "rest", request_type=compute.SetUrlMapRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -1341,7 +1341,7 @@ def test_set_url_map_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_url_map(request)
+        response = client.set_url_map_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1369,7 +1369,7 @@ def test_set_url_map_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_url_map_rest_bad_request(
+def test_set_url_map_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetUrlMapRegionTargetHttpsProxyRequest
 ):
     client = RegionTargetHttpsProxiesClient(
@@ -1396,14 +1396,14 @@ def test_set_url_map_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_url_map(request)
+        client.set_url_map_unary(request)
 
 
-def test_set_url_map_rest_from_dict():
-    test_set_url_map_rest(request_type=dict)
+def test_set_url_map_unary_rest_from_dict():
+    test_set_url_map_unary_rest(request_type=dict)
 
 
-def test_set_url_map_rest_flattened(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1436,7 +1436,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
             url_map_reference_resource=compute.UrlMapReference(url_map="url_map_value"),
         )
         mock_args.update(sample_request)
-        client.set_url_map(**mock_args)
+        client.set_url_map_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1449,7 +1449,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest_flattened_error(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionTargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1457,7 +1457,7 @@ def test_set_url_map_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_url_map(
+        client.set_url_map_unary(
             compute.SetUrlMapRegionTargetHttpsProxyRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_region_url_maps.py
+++ b/tests/unit/gapic/compute_v1/test_region_url_maps.py
@@ -408,7 +408,7 @@ def test_region_url_maps_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -453,7 +453,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -481,7 +481,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -501,14 +501,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -538,7 +538,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", region="region_value", url_map="url_map_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -551,7 +551,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -559,7 +559,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRegionUrlMapRequest(),
             project="project_value",
             region="region_value",
@@ -698,7 +698,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -746,7 +746,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -774,7 +774,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -797,14 +797,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -834,7 +834,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -847,7 +847,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -855,7 +855,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRegionUrlMapRequest(),
             project="project_value",
             region="region_value",
@@ -1022,7 +1022,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -1070,7 +1070,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1098,7 +1098,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -1121,14 +1121,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1163,7 +1163,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1176,7 +1176,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1184,7 +1184,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRegionUrlMapRequest(),
             project="project_value",
             region="region_value",
@@ -1195,7 +1195,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(
+def test_update_unary_rest(
     transport: str = "rest", request_type=compute.UpdateRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -1243,7 +1243,7 @@ def test_update_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1271,7 +1271,7 @@ def test_update_rest(
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateRegionUrlMapRequest
 ):
     client = RegionUrlMapsClient(
@@ -1294,14 +1294,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1336,7 +1336,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1349,7 +1349,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = RegionUrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1357,7 +1357,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateRegionUrlMapRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_reservations.py
+++ b/tests/unit/gapic/compute_v1/test_reservations.py
@@ -581,7 +581,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteReservationRequest
 ):
     client = ReservationsClient(
@@ -626,7 +626,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -654,7 +654,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteReservationRequest
 ):
     client = ReservationsClient(
@@ -674,14 +674,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -711,7 +711,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", zone="zone_value", reservation="reservation_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -724,7 +724,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -732,7 +732,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteReservationRequest(),
             project="project_value",
             zone="zone_value",
@@ -992,7 +992,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertReservationRequest
 ):
     client = ReservationsClient(
@@ -1040,7 +1040,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1068,7 +1068,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertReservationRequest
 ):
     client = ReservationsClient(
@@ -1091,14 +1091,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1126,7 +1126,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             reservation_resource=compute.Reservation(commitment="commitment_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1139,7 +1139,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1147,7 +1147,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertReservationRequest(),
             project="project_value",
             zone="zone_value",
@@ -1320,7 +1320,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_resize_rest(
+def test_resize_unary_rest(
     transport: str = "rest", request_type=compute.ResizeReservationRequest
 ):
     client = ReservationsClient(
@@ -1368,7 +1368,7 @@ def test_resize_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.resize(request)
+        response = client.resize_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1396,7 +1396,7 @@ def test_resize_rest(
     assert response.zone == "zone_value"
 
 
-def test_resize_rest_bad_request(
+def test_resize_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ResizeReservationRequest
 ):
     client = ReservationsClient(
@@ -1419,14 +1419,14 @@ def test_resize_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.resize(request)
+        client.resize_unary(request)
 
 
-def test_resize_rest_from_dict():
-    test_resize_rest(request_type=dict)
+def test_resize_unary_rest_from_dict():
+    test_resize_unary_rest(request_type=dict)
 
 
-def test_resize_rest_flattened(transport: str = "rest"):
+def test_resize_unary_rest_flattened(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1461,7 +1461,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.resize(**mock_args)
+        client.resize_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1474,7 +1474,7 @@ def test_resize_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_resize_rest_flattened_error(transport: str = "rest"):
+def test_resize_unary_rest_flattened_error(transport: str = "rest"):
     client = ReservationsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1482,7 +1482,7 @@ def test_resize_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.resize(
+        client.resize_unary(
             compute.ResizeReservationRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_resource_policies.py
+++ b/tests/unit/gapic/compute_v1/test_resource_policies.py
@@ -605,7 +605,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteResourcePolicyRequest
 ):
     client = ResourcePoliciesClient(
@@ -654,7 +654,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -682,7 +682,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteResourcePolicyRequest
 ):
     client = ResourcePoliciesClient(
@@ -706,14 +706,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ResourcePoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -745,7 +745,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             resource_policy="resource_policy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -758,7 +758,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ResourcePoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -766,7 +766,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteResourcePolicyRequest(),
             project="project_value",
             region="region_value",
@@ -1032,7 +1032,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertResourcePolicyRequest
 ):
     client = ResourcePoliciesClient(
@@ -1080,7 +1080,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1108,7 +1108,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertResourcePolicyRequest
 ):
     client = ResourcePoliciesClient(
@@ -1131,14 +1131,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ResourcePoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1168,7 +1168,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1181,7 +1181,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ResourcePoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1189,7 +1189,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertResourcePolicyRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_routers.py
+++ b/tests/unit/gapic/compute_v1/test_routers.py
@@ -571,7 +571,9 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouterRequest):
+def test_delete_unary_rest(
+    transport: str = "rest", request_type=compute.DeleteRouterRequest
+):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -614,7 +616,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouterR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -642,7 +644,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouterR
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRouterRequest
 ):
     client = RoutersClient(
@@ -662,14 +664,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -699,7 +701,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", region="region_value", router="router_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -712,7 +714,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -720,7 +722,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRouterRequest(),
             project="project_value",
             region="region_value",
@@ -1153,7 +1155,9 @@ def test_get_router_status_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouterRequest):
+def test_insert_unary_rest(
+    transport: str = "rest", request_type=compute.InsertRouterRequest
+):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1199,7 +1203,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouterR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1227,7 +1231,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouterR
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRouterRequest
 ):
     client = RoutersClient(
@@ -1250,14 +1254,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1287,7 +1291,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1300,7 +1304,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1308,7 +1312,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRouterRequest(),
             project="project_value",
             region="region_value",
@@ -1473,7 +1477,9 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(transport: str = "rest", request_type=compute.PatchRouterRequest):
+def test_patch_unary_rest(
+    transport: str = "rest", request_type=compute.PatchRouterRequest
+):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1519,7 +1525,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchRouterReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1547,7 +1553,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchRouterReq
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRouterRequest
 ):
     client = RoutersClient(
@@ -1570,14 +1576,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1612,7 +1618,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1625,7 +1631,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1633,7 +1639,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchRouterRequest(),
             project="project_value",
             region="region_value",
@@ -1772,7 +1778,9 @@ def test_preview_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(transport: str = "rest", request_type=compute.UpdateRouterRequest):
+def test_update_unary_rest(
+    transport: str = "rest", request_type=compute.UpdateRouterRequest
+):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1818,7 +1826,7 @@ def test_update_rest(transport: str = "rest", request_type=compute.UpdateRouterR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1846,7 +1854,7 @@ def test_update_rest(transport: str = "rest", request_type=compute.UpdateRouterR
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateRouterRequest
 ):
     client = RoutersClient(
@@ -1869,14 +1877,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1911,7 +1919,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1924,7 +1932,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutersClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1932,7 +1940,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateRouterRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_routes.py
+++ b/tests/unit/gapic/compute_v1/test_routes.py
@@ -394,7 +394,9 @@ def test_routes_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouteRequest):
+def test_delete_unary_rest(
+    transport: str = "rest", request_type=compute.DeleteRouteRequest
+):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -437,7 +439,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouteRe
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -465,7 +467,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteRouteRe
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteRouteRequest
 ):
     client = RoutesClient(
@@ -485,14 +487,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -516,7 +518,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", route="route_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -529,7 +531,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -537,7 +539,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteRouteRequest(), project="project_value", route="route_value",
         )
 
@@ -682,7 +684,9 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouteRequest):
+def test_insert_unary_rest(
+    transport: str = "rest", request_type=compute.InsertRouteRequest
+):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -728,7 +732,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouteRe
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -756,7 +760,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertRouteRe
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertRouteRequest
 ):
     client = RoutesClient(
@@ -779,14 +783,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -815,7 +819,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -828,7 +832,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = RoutesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -836,7 +840,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertRouteRequest(),
             project="project_value",
             route_resource=compute.Route(

--- a/tests/unit/gapic/compute_v1/test_security_policies.py
+++ b/tests/unit/gapic/compute_v1/test_security_policies.py
@@ -420,7 +420,7 @@ def test_security_policies_client_client_options_credentials_file(
         )
 
 
-def test_add_rule_rest(
+def test_add_rule_unary_rest(
     transport: str = "rest", request_type=compute.AddRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -468,7 +468,7 @@ def test_add_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_rule(request)
+        response = client.add_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -496,7 +496,7 @@ def test_add_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_rule_rest_bad_request(
+def test_add_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -519,14 +519,14 @@ def test_add_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_rule(request)
+        client.add_rule_unary(request)
 
 
-def test_add_rule_rest_from_dict():
-    test_add_rule_rest(request_type=dict)
+def test_add_rule_unary_rest_from_dict():
+    test_add_rule_unary_rest(request_type=dict)
 
 
-def test_add_rule_rest_flattened(transport: str = "rest"):
+def test_add_rule_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -556,7 +556,7 @@ def test_add_rule_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_rule(**mock_args)
+        client.add_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -569,7 +569,7 @@ def test_add_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_rule_rest_flattened_error(transport: str = "rest"):
+def test_add_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -577,7 +577,7 @@ def test_add_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_rule(
+        client.add_rule_unary(
             compute.AddRuleSecurityPolicyRequest(),
             project="project_value",
             security_policy="security_policy_value",
@@ -587,7 +587,7 @@ def test_add_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -632,7 +632,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -660,7 +660,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -680,14 +680,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -713,7 +713,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", security_policy="security_policy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -726,7 +726,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -734,7 +734,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteSecurityPolicyRequest(),
             project="project_value",
             security_policy="security_policy_value",
@@ -985,7 +985,7 @@ def test_get_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1037,7 +1037,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1065,7 +1065,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1092,14 +1092,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1132,7 +1132,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1145,7 +1145,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1153,7 +1153,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertSecurityPolicyRequest(),
             project="project_value",
             security_policy_resource=compute.SecurityPolicy(
@@ -1441,7 +1441,7 @@ def test_list_preconfigured_expression_sets_rest_flattened_error(
         )
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1493,7 +1493,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1521,7 +1521,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1548,14 +1548,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1589,7 +1589,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1602,7 +1602,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1610,7 +1610,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchSecurityPolicyRequest(),
             project="project_value",
             security_policy="security_policy_value",
@@ -1624,7 +1624,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_patch_rule_rest(
+def test_patch_rule_unary_rest(
     transport: str = "rest", request_type=compute.PatchRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1672,7 +1672,7 @@ def test_patch_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch_rule(request)
+        response = client.patch_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1700,7 +1700,7 @@ def test_patch_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rule_rest_bad_request(
+def test_patch_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1723,14 +1723,14 @@ def test_patch_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch_rule(request)
+        client.patch_rule_unary(request)
 
 
-def test_patch_rule_rest_from_dict():
-    test_patch_rule_rest(request_type=dict)
+def test_patch_rule_unary_rest_from_dict():
+    test_patch_rule_unary_rest(request_type=dict)
 
 
-def test_patch_rule_rest_flattened(transport: str = "rest"):
+def test_patch_rule_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1760,7 +1760,7 @@ def test_patch_rule_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch_rule(**mock_args)
+        client.patch_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1773,7 +1773,7 @@ def test_patch_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rule_rest_flattened_error(transport: str = "rest"):
+def test_patch_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1781,7 +1781,7 @@ def test_patch_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch_rule(
+        client.patch_rule_unary(
             compute.PatchRuleSecurityPolicyRequest(),
             project="project_value",
             security_policy="security_policy_value",
@@ -1791,7 +1791,7 @@ def test_patch_rule_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_remove_rule_rest(
+def test_remove_rule_unary_rest(
     transport: str = "rest", request_type=compute.RemoveRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1836,7 +1836,7 @@ def test_remove_rule_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_rule(request)
+        response = client.remove_rule_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1864,7 +1864,7 @@ def test_remove_rule_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_rule_rest_bad_request(
+def test_remove_rule_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveRuleSecurityPolicyRequest
 ):
     client = SecurityPoliciesClient(
@@ -1884,14 +1884,14 @@ def test_remove_rule_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_rule(request)
+        client.remove_rule_unary(request)
 
 
-def test_remove_rule_rest_from_dict():
-    test_remove_rule_rest(request_type=dict)
+def test_remove_rule_unary_rest_from_dict():
+    test_remove_rule_unary_rest(request_type=dict)
 
 
-def test_remove_rule_rest_flattened(transport: str = "rest"):
+def test_remove_rule_unary_rest_flattened(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1917,7 +1917,7 @@ def test_remove_rule_rest_flattened(transport: str = "rest"):
             project="project_value", security_policy="security_policy_value",
         )
         mock_args.update(sample_request)
-        client.remove_rule(**mock_args)
+        client.remove_rule_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1930,7 +1930,7 @@ def test_remove_rule_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_rule_rest_flattened_error(transport: str = "rest"):
+def test_remove_rule_unary_rest_flattened_error(transport: str = "rest"):
     client = SecurityPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1938,7 +1938,7 @@ def test_remove_rule_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_rule(
+        client.remove_rule_unary(
             compute.RemoveRuleSecurityPolicyRequest(),
             project="project_value",
             security_policy="security_policy_value",

--- a/tests/unit/gapic/compute_v1/test_service_attachments.py
+++ b/tests/unit/gapic/compute_v1/test_service_attachments.py
@@ -613,7 +613,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -662,7 +662,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -690,7 +690,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -714,14 +714,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -753,7 +753,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             service_attachment="service_attachment_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -766,7 +766,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -774,7 +774,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteServiceAttachmentRequest(),
             project="project_value",
             region="region_value",
@@ -1052,7 +1052,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -1102,7 +1102,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1130,7 +1130,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -1155,14 +1155,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1196,7 +1196,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1209,7 +1209,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1217,7 +1217,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertServiceAttachmentRequest(),
             project="project_value",
             region="region_value",
@@ -1398,7 +1398,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -1452,7 +1452,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1480,7 +1480,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchServiceAttachmentRequest
 ):
     client = ServiceAttachmentsClient(
@@ -1509,14 +1509,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1555,7 +1555,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1568,7 +1568,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = ServiceAttachmentsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1576,7 +1576,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchServiceAttachmentRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_snapshots.py
+++ b/tests/unit/gapic/compute_v1/test_snapshots.py
@@ -397,7 +397,7 @@ def test_snapshots_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSnapshotRequest
 ):
     client = SnapshotsClient(
@@ -442,7 +442,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -470,7 +470,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSnapshotRequest
 ):
     client = SnapshotsClient(
@@ -490,14 +490,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = SnapshotsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -521,7 +521,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", snapshot="snapshot_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -534,7 +534,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = SnapshotsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -542,7 +542,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteSnapshotRequest(),
             project="project_value",
             snapshot="snapshot_value",
@@ -1085,7 +1085,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsSnapshotRequest
 ):
     client = SnapshotsClient(
@@ -1133,7 +1133,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1161,7 +1161,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsSnapshotRequest
 ):
     client = SnapshotsClient(
@@ -1184,14 +1184,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = SnapshotsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1221,7 +1221,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1234,7 +1234,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = SnapshotsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1242,7 +1242,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsSnapshotRequest(),
             project="project_value",
             resource="resource_value",

--- a/tests/unit/gapic/compute_v1/test_ssl_certificates.py
+++ b/tests/unit/gapic/compute_v1/test_ssl_certificates.py
@@ -602,7 +602,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSslCertificateRequest
 ):
     client = SslCertificatesClient(
@@ -647,7 +647,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -675,7 +675,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSslCertificateRequest
 ):
     client = SslCertificatesClient(
@@ -695,14 +695,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = SslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -728,7 +728,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", ssl_certificate="ssl_certificate_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -741,7 +741,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = SslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -749,7 +749,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteSslCertificateRequest(),
             project="project_value",
             ssl_certificate="ssl_certificate_value",
@@ -890,7 +890,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertSslCertificateRequest
 ):
     client = SslCertificatesClient(
@@ -938,7 +938,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -966,7 +966,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertSslCertificateRequest
 ):
     client = SslCertificatesClient(
@@ -989,14 +989,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = SslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1025,7 +1025,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1038,7 +1038,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = SslCertificatesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1046,7 +1046,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertSslCertificateRequest(),
             project="project_value",
             ssl_certificate_resource=compute.SslCertificate(

--- a/tests/unit/gapic/compute_v1/test_ssl_policies.py
+++ b/tests/unit/gapic/compute_v1/test_ssl_policies.py
@@ -401,7 +401,7 @@ def test_ssl_policies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -446,7 +446,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -474,7 +474,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -494,14 +494,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -525,7 +525,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", ssl_policy="ssl_policy_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -538,7 +538,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -546,7 +546,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteSslPolicyRequest(),
             project="project_value",
             ssl_policy="ssl_policy_value",
@@ -681,7 +681,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -729,7 +729,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -757,7 +757,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -780,14 +780,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -816,7 +816,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -829,7 +829,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -837,7 +837,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertSslPolicyRequest(),
             project="project_value",
             ssl_policy_resource=compute.SslPolicy(
@@ -1117,7 +1117,7 @@ def test_list_available_features_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -1165,7 +1165,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1193,7 +1193,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchSslPolicyRequest
 ):
     client = SslPoliciesClient(
@@ -1216,14 +1216,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1253,7 +1253,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1266,7 +1266,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = SslPoliciesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1274,7 +1274,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchSslPolicyRequest(),
             project="project_value",
             ssl_policy="ssl_policy_value",

--- a/tests/unit/gapic/compute_v1/test_subnetworks.py
+++ b/tests/unit/gapic/compute_v1/test_subnetworks.py
@@ -581,7 +581,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -626,7 +626,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -654,7 +654,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -674,14 +674,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -713,7 +713,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             subnetwork="subnetwork_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -726,7 +726,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -734,7 +734,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteSubnetworkRequest(),
             project="project_value",
             region="region_value",
@@ -742,7 +742,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_expand_ip_cidr_range_rest(
+def test_expand_ip_cidr_range_unary_rest(
     transport: str = "rest", request_type=compute.ExpandIpCidrRangeSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -790,7 +790,7 @@ def test_expand_ip_cidr_range_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.expand_ip_cidr_range(request)
+        response = client.expand_ip_cidr_range_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -818,7 +818,7 @@ def test_expand_ip_cidr_range_rest(
     assert response.zone == "zone_value"
 
 
-def test_expand_ip_cidr_range_rest_bad_request(
+def test_expand_ip_cidr_range_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.ExpandIpCidrRangeSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -841,14 +841,14 @@ def test_expand_ip_cidr_range_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.expand_ip_cidr_range(request)
+        client.expand_ip_cidr_range_unary(request)
 
 
-def test_expand_ip_cidr_range_rest_from_dict():
-    test_expand_ip_cidr_range_rest(request_type=dict)
+def test_expand_ip_cidr_range_unary_rest_from_dict():
+    test_expand_ip_cidr_range_unary_rest(request_type=dict)
 
 
-def test_expand_ip_cidr_range_rest_flattened(transport: str = "rest"):
+def test_expand_ip_cidr_range_unary_rest_flattened(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -883,7 +883,7 @@ def test_expand_ip_cidr_range_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.expand_ip_cidr_range(**mock_args)
+        client.expand_ip_cidr_range_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -896,7 +896,7 @@ def test_expand_ip_cidr_range_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_expand_ip_cidr_range_rest_flattened_error(transport: str = "rest"):
+def test_expand_ip_cidr_range_unary_rest_flattened_error(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -904,7 +904,7 @@ def test_expand_ip_cidr_range_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.expand_ip_cidr_range(
+        client.expand_ip_cidr_range_unary(
             compute.ExpandIpCidrRangeSubnetworkRequest(),
             project="project_value",
             region="region_value",
@@ -1189,7 +1189,7 @@ def test_get_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -1237,7 +1237,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1265,7 +1265,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -1288,14 +1288,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1325,7 +1325,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1338,7 +1338,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1346,7 +1346,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertSubnetworkRequest(),
             project="project_value",
             region="region_value",
@@ -1690,7 +1690,7 @@ def test_list_usable_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -1738,7 +1738,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1766,7 +1766,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchSubnetworkRequest
 ):
     client = SubnetworksClient(
@@ -1789,14 +1789,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1831,7 +1831,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1844,7 +1844,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1852,7 +1852,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchSubnetworkRequest(),
             project="project_value",
             region="region_value",
@@ -1994,7 +1994,7 @@ def test_set_iam_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_private_ip_google_access_rest(
+def test_set_private_ip_google_access_unary_rest(
     transport: str = "rest",
     request_type=compute.SetPrivateIpGoogleAccessSubnetworkRequest,
 ):
@@ -2045,7 +2045,7 @@ def test_set_private_ip_google_access_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_private_ip_google_access(request)
+        response = client.set_private_ip_google_access_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2073,7 +2073,7 @@ def test_set_private_ip_google_access_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_private_ip_google_access_rest_bad_request(
+def test_set_private_ip_google_access_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetPrivateIpGoogleAccessSubnetworkRequest,
 ):
@@ -2099,14 +2099,14 @@ def test_set_private_ip_google_access_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_private_ip_google_access(request)
+        client.set_private_ip_google_access_unary(request)
 
 
-def test_set_private_ip_google_access_rest_from_dict():
-    test_set_private_ip_google_access_rest(request_type=dict)
+def test_set_private_ip_google_access_unary_rest_from_dict():
+    test_set_private_ip_google_access_unary_rest(request_type=dict)
 
 
-def test_set_private_ip_google_access_rest_flattened(transport: str = "rest"):
+def test_set_private_ip_google_access_unary_rest_flattened(transport: str = "rest"):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2141,7 +2141,7 @@ def test_set_private_ip_google_access_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_private_ip_google_access(**mock_args)
+        client.set_private_ip_google_access_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2154,7 +2154,9 @@ def test_set_private_ip_google_access_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_private_ip_google_access_rest_flattened_error(transport: str = "rest"):
+def test_set_private_ip_google_access_unary_rest_flattened_error(
+    transport: str = "rest",
+):
     client = SubnetworksClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2162,7 +2164,7 @@ def test_set_private_ip_google_access_rest_flattened_error(transport: str = "res
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_private_ip_google_access(
+        client.set_private_ip_google_access_unary(
             compute.SetPrivateIpGoogleAccessSubnetworkRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_target_grpc_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_target_grpc_proxies.py
@@ -420,7 +420,7 @@ def test_target_grpc_proxies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -465,7 +465,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -493,7 +493,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -513,14 +513,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -546,7 +546,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", target_grpc_proxy="target_grpc_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -559,7 +559,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -567,7 +567,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetGrpcProxyRequest(),
             project="project_value",
             target_grpc_proxy="target_grpc_proxy_value",
@@ -704,7 +704,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -752,7 +752,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -780,7 +780,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -803,14 +803,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -839,7 +839,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -852,7 +852,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -860,7 +860,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetGrpcProxyRequest(),
             project="project_value",
             target_grpc_proxy_resource=compute.TargetGrpcProxy(
@@ -1032,7 +1032,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -1080,7 +1080,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1108,7 +1108,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchTargetGrpcProxyRequest
 ):
     client = TargetGrpcProxiesClient(
@@ -1131,14 +1131,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1168,7 +1168,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1181,7 +1181,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetGrpcProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1189,7 +1189,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchTargetGrpcProxyRequest(),
             project="project_value",
             target_grpc_proxy="target_grpc_proxy_value",

--- a/tests/unit/gapic/compute_v1/test_target_http_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_target_http_proxies.py
@@ -603,7 +603,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -648,7 +648,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -676,7 +676,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -696,14 +696,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -729,7 +729,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", target_http_proxy="target_http_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -742,7 +742,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -750,7 +750,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetHttpProxyRequest(),
             project="project_value",
             target_http_proxy="target_http_proxy_value",
@@ -887,7 +887,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -935,7 +935,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -963,7 +963,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -986,14 +986,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1022,7 +1022,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1035,7 +1035,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1043,7 +1043,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetHttpProxyRequest(),
             project="project_value",
             target_http_proxy_resource=compute.TargetHttpProxy(
@@ -1215,7 +1215,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -1263,7 +1263,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1291,7 +1291,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -1314,14 +1314,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1351,7 +1351,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1364,7 +1364,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1372,7 +1372,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchTargetHttpProxyRequest(),
             project="project_value",
             target_http_proxy="target_http_proxy_value",
@@ -1382,7 +1382,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest(
+def test_set_url_map_unary_rest(
     transport: str = "rest", request_type=compute.SetUrlMapTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -1430,7 +1430,7 @@ def test_set_url_map_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_url_map(request)
+        response = client.set_url_map_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1458,7 +1458,7 @@ def test_set_url_map_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_url_map_rest_bad_request(
+def test_set_url_map_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetUrlMapTargetHttpProxyRequest
 ):
     client = TargetHttpProxiesClient(
@@ -1481,14 +1481,14 @@ def test_set_url_map_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_url_map(request)
+        client.set_url_map_unary(request)
 
 
-def test_set_url_map_rest_from_dict():
-    test_set_url_map_rest(request_type=dict)
+def test_set_url_map_unary_rest_from_dict():
+    test_set_url_map_unary_rest(request_type=dict)
 
 
-def test_set_url_map_rest_flattened(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1516,7 +1516,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
             url_map_reference_resource=compute.UrlMapReference(url_map="url_map_value"),
         )
         mock_args.update(sample_request)
-        client.set_url_map(**mock_args)
+        client.set_url_map_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1529,7 +1529,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest_flattened_error(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1537,7 +1537,7 @@ def test_set_url_map_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_url_map(
+        client.set_url_map_unary(
             compute.SetUrlMapTargetHttpProxyRequest(),
             project="project_value",
             target_http_proxy="target_http_proxy_value",

--- a/tests/unit/gapic/compute_v1/test_target_https_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_target_https_proxies.py
@@ -609,7 +609,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -654,7 +654,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -682,7 +682,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -702,14 +702,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -735,7 +735,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", target_https_proxy="target_https_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -748,7 +748,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -756,7 +756,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",
@@ -903,7 +903,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -951,7 +951,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -979,7 +979,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1002,14 +1002,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1038,7 +1038,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1051,7 +1051,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1059,7 +1059,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy_resource=compute.TargetHttpsProxy(
@@ -1233,7 +1233,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(
+def test_patch_unary_rest(
     transport: str = "rest", request_type=compute.PatchTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1281,7 +1281,7 @@ def test_patch_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1309,7 +1309,7 @@ def test_patch_rest(
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1332,14 +1332,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1369,7 +1369,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1382,7 +1382,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1390,7 +1390,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",
@@ -1400,7 +1400,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_quic_override_rest(
+def test_set_quic_override_unary_rest(
     transport: str = "rest", request_type=compute.SetQuicOverrideTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1450,7 +1450,7 @@ def test_set_quic_override_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_quic_override(request)
+        response = client.set_quic_override_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1478,7 +1478,7 @@ def test_set_quic_override_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_quic_override_rest_bad_request(
+def test_set_quic_override_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetQuicOverrideTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1503,14 +1503,14 @@ def test_set_quic_override_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_quic_override(request)
+        client.set_quic_override_unary(request)
 
 
-def test_set_quic_override_rest_from_dict():
-    test_set_quic_override_rest(request_type=dict)
+def test_set_quic_override_unary_rest_from_dict():
+    test_set_quic_override_unary_rest(request_type=dict)
 
 
-def test_set_quic_override_rest_flattened(transport: str = "rest"):
+def test_set_quic_override_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1540,7 +1540,7 @@ def test_set_quic_override_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_quic_override(**mock_args)
+        client.set_quic_override_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1553,7 +1553,7 @@ def test_set_quic_override_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_quic_override_rest_flattened_error(transport: str = "rest"):
+def test_set_quic_override_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1561,7 +1561,7 @@ def test_set_quic_override_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_quic_override(
+        client.set_quic_override_unary(
             compute.SetQuicOverrideTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",
@@ -1571,7 +1571,7 @@ def test_set_quic_override_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_ssl_certificates_rest(
+def test_set_ssl_certificates_unary_rest(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesTargetHttpsProxyRequest,
 ):
@@ -1622,7 +1622,7 @@ def test_set_ssl_certificates_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_ssl_certificates(request)
+        response = client.set_ssl_certificates_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1650,7 +1650,7 @@ def test_set_ssl_certificates_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_ssl_certificates_rest_bad_request(
+def test_set_ssl_certificates_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesTargetHttpsProxyRequest,
 ):
@@ -1676,14 +1676,14 @@ def test_set_ssl_certificates_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_ssl_certificates(request)
+        client.set_ssl_certificates_unary(request)
 
 
-def test_set_ssl_certificates_rest_from_dict():
-    test_set_ssl_certificates_rest(request_type=dict)
+def test_set_ssl_certificates_unary_rest_from_dict():
+    test_set_ssl_certificates_unary_rest(request_type=dict)
 
 
-def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1713,7 +1713,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_ssl_certificates(**mock_args)
+        client.set_ssl_certificates_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1726,7 +1726,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1734,7 +1734,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_ssl_certificates(
+        client.set_ssl_certificates_unary(
             compute.SetSslCertificatesTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",
@@ -1744,7 +1744,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_ssl_policy_rest(
+def test_set_ssl_policy_unary_rest(
     transport: str = "rest", request_type=compute.SetSslPolicyTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1792,7 +1792,7 @@ def test_set_ssl_policy_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_ssl_policy(request)
+        response = client.set_ssl_policy_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1820,7 +1820,7 @@ def test_set_ssl_policy_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_ssl_policy_rest_bad_request(
+def test_set_ssl_policy_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetSslPolicyTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1843,14 +1843,14 @@ def test_set_ssl_policy_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_ssl_policy(request)
+        client.set_ssl_policy_unary(request)
 
 
-def test_set_ssl_policy_rest_from_dict():
-    test_set_ssl_policy_rest(request_type=dict)
+def test_set_ssl_policy_unary_rest_from_dict():
+    test_set_ssl_policy_unary_rest(request_type=dict)
 
 
-def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
+def test_set_ssl_policy_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1880,7 +1880,7 @@ def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_ssl_policy(**mock_args)
+        client.set_ssl_policy_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1893,7 +1893,7 @@ def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_ssl_policy_rest_flattened_error(transport: str = "rest"):
+def test_set_ssl_policy_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1901,7 +1901,7 @@ def test_set_ssl_policy_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_ssl_policy(
+        client.set_ssl_policy_unary(
             compute.SetSslPolicyTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",
@@ -1911,7 +1911,7 @@ def test_set_ssl_policy_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest(
+def test_set_url_map_unary_rest(
     transport: str = "rest", request_type=compute.SetUrlMapTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -1959,7 +1959,7 @@ def test_set_url_map_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_url_map(request)
+        response = client.set_url_map_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1987,7 +1987,7 @@ def test_set_url_map_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_url_map_rest_bad_request(
+def test_set_url_map_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetUrlMapTargetHttpsProxyRequest
 ):
     client = TargetHttpsProxiesClient(
@@ -2010,14 +2010,14 @@ def test_set_url_map_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_url_map(request)
+        client.set_url_map_unary(request)
 
 
-def test_set_url_map_rest_from_dict():
-    test_set_url_map_rest(request_type=dict)
+def test_set_url_map_unary_rest_from_dict():
+    test_set_url_map_unary_rest(request_type=dict)
 
 
-def test_set_url_map_rest_flattened(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2045,7 +2045,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
             url_map_reference_resource=compute.UrlMapReference(url_map="url_map_value"),
         )
         mock_args.update(sample_request)
-        client.set_url_map(**mock_args)
+        client.set_url_map_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2058,7 +2058,7 @@ def test_set_url_map_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_url_map_rest_flattened_error(transport: str = "rest"):
+def test_set_url_map_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetHttpsProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2066,7 +2066,7 @@ def test_set_url_map_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_url_map(
+        client.set_url_map_unary(
             compute.SetUrlMapTargetHttpsProxyRequest(),
             project="project_value",
             target_https_proxy="target_https_proxy_value",

--- a/tests/unit/gapic/compute_v1/test_target_instances.py
+++ b/tests/unit/gapic/compute_v1/test_target_instances.py
@@ -602,7 +602,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetInstanceRequest
 ):
     client = TargetInstancesClient(
@@ -651,7 +651,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -679,7 +679,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetInstanceRequest
 ):
     client = TargetInstancesClient(
@@ -703,14 +703,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -742,7 +742,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             target_instance="target_instance_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -755,7 +755,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -763,7 +763,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetInstanceRequest(),
             project="project_value",
             zone="zone_value",
@@ -916,7 +916,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetInstanceRequest
 ):
     client = TargetInstancesClient(
@@ -964,7 +964,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -992,7 +992,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetInstanceRequest
 ):
     client = TargetInstancesClient(
@@ -1015,14 +1015,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1052,7 +1052,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1065,7 +1065,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetInstancesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1073,7 +1073,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetInstanceRequest(),
             project="project_value",
             zone="zone_value",

--- a/tests/unit/gapic/compute_v1/test_target_pools.py
+++ b/tests/unit/gapic/compute_v1/test_target_pools.py
@@ -401,7 +401,7 @@ def test_target_pools_client_client_options_credentials_file(
         )
 
 
-def test_add_health_check_rest(
+def test_add_health_check_unary_rest(
     transport: str = "rest", request_type=compute.AddHealthCheckTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -451,7 +451,7 @@ def test_add_health_check_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_health_check(request)
+        response = client.add_health_check_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -479,7 +479,7 @@ def test_add_health_check_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_health_check_rest_bad_request(
+def test_add_health_check_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddHealthCheckTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -504,14 +504,14 @@ def test_add_health_check_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_health_check(request)
+        client.add_health_check_unary(request)
 
 
-def test_add_health_check_rest_from_dict():
-    test_add_health_check_rest(request_type=dict)
+def test_add_health_check_unary_rest_from_dict():
+    test_add_health_check_unary_rest(request_type=dict)
 
 
-def test_add_health_check_rest_flattened(transport: str = "rest"):
+def test_add_health_check_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -548,7 +548,7 @@ def test_add_health_check_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_health_check(**mock_args)
+        client.add_health_check_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -561,7 +561,7 @@ def test_add_health_check_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_health_check_rest_flattened_error(transport: str = "rest"):
+def test_add_health_check_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -569,7 +569,7 @@ def test_add_health_check_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_health_check(
+        client.add_health_check_unary(
             compute.AddHealthCheckTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -582,7 +582,7 @@ def test_add_health_check_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_add_instance_rest(
+def test_add_instance_unary_rest(
     transport: str = "rest", request_type=compute.AddInstanceTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -632,7 +632,7 @@ def test_add_instance_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.add_instance(request)
+        response = client.add_instance_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -660,7 +660,7 @@ def test_add_instance_rest(
     assert response.zone == "zone_value"
 
 
-def test_add_instance_rest_bad_request(
+def test_add_instance_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.AddInstanceTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -685,14 +685,14 @@ def test_add_instance_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.add_instance(request)
+        client.add_instance_unary(request)
 
 
-def test_add_instance_rest_from_dict():
-    test_add_instance_rest(request_type=dict)
+def test_add_instance_unary_rest_from_dict():
+    test_add_instance_unary_rest(request_type=dict)
 
 
-def test_add_instance_rest_flattened(transport: str = "rest"):
+def test_add_instance_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -727,7 +727,7 @@ def test_add_instance_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.add_instance(**mock_args)
+        client.add_instance_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -740,7 +740,7 @@ def test_add_instance_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_add_instance_rest_flattened_error(transport: str = "rest"):
+def test_add_instance_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -748,7 +748,7 @@ def test_add_instance_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.add_instance(
+        client.add_instance_unary(
             compute.AddInstanceTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -939,7 +939,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -984,7 +984,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1012,7 +1012,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1032,14 +1032,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1071,7 +1071,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             target_pool="target_pool_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1084,7 +1084,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1092,7 +1092,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -1368,7 +1368,7 @@ def test_get_health_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1416,7 +1416,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1444,7 +1444,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1467,14 +1467,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1502,7 +1502,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             target_pool_resource=compute.TargetPool(backup_pool="backup_pool_value"),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1515,7 +1515,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1523,7 +1523,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -1696,7 +1696,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_remove_health_check_rest(
+def test_remove_health_check_unary_rest(
     transport: str = "rest", request_type=compute.RemoveHealthCheckTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1746,7 +1746,7 @@ def test_remove_health_check_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_health_check(request)
+        response = client.remove_health_check_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1774,7 +1774,7 @@ def test_remove_health_check_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_health_check_rest_bad_request(
+def test_remove_health_check_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveHealthCheckTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1799,14 +1799,14 @@ def test_remove_health_check_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_health_check(request)
+        client.remove_health_check_unary(request)
 
 
-def test_remove_health_check_rest_from_dict():
-    test_remove_health_check_rest(request_type=dict)
+def test_remove_health_check_unary_rest_from_dict():
+    test_remove_health_check_unary_rest(request_type=dict)
 
 
-def test_remove_health_check_rest_flattened(transport: str = "rest"):
+def test_remove_health_check_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1843,7 +1843,7 @@ def test_remove_health_check_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_health_check(**mock_args)
+        client.remove_health_check_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1856,7 +1856,7 @@ def test_remove_health_check_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_health_check_rest_flattened_error(transport: str = "rest"):
+def test_remove_health_check_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1864,7 +1864,7 @@ def test_remove_health_check_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_health_check(
+        client.remove_health_check_unary(
             compute.RemoveHealthCheckTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -1877,7 +1877,7 @@ def test_remove_health_check_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_remove_instance_rest(
+def test_remove_instance_unary_rest(
     transport: str = "rest", request_type=compute.RemoveInstanceTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1927,7 +1927,7 @@ def test_remove_instance_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.remove_instance(request)
+        response = client.remove_instance_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1955,7 +1955,7 @@ def test_remove_instance_rest(
     assert response.zone == "zone_value"
 
 
-def test_remove_instance_rest_bad_request(
+def test_remove_instance_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.RemoveInstanceTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -1980,14 +1980,14 @@ def test_remove_instance_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.remove_instance(request)
+        client.remove_instance_unary(request)
 
 
-def test_remove_instance_rest_from_dict():
-    test_remove_instance_rest(request_type=dict)
+def test_remove_instance_unary_rest_from_dict():
+    test_remove_instance_unary_rest(request_type=dict)
 
 
-def test_remove_instance_rest_flattened(transport: str = "rest"):
+def test_remove_instance_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2022,7 +2022,7 @@ def test_remove_instance_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.remove_instance(**mock_args)
+        client.remove_instance_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2035,7 +2035,7 @@ def test_remove_instance_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_remove_instance_rest_flattened_error(transport: str = "rest"):
+def test_remove_instance_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2043,7 +2043,7 @@ def test_remove_instance_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.remove_instance(
+        client.remove_instance_unary(
             compute.RemoveInstanceTargetPoolRequest(),
             project="project_value",
             region="region_value",
@@ -2054,7 +2054,7 @@ def test_remove_instance_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_backup_rest(
+def test_set_backup_unary_rest(
     transport: str = "rest", request_type=compute.SetBackupTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -2102,7 +2102,7 @@ def test_set_backup_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_backup(request)
+        response = client.set_backup_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -2130,7 +2130,7 @@ def test_set_backup_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_backup_rest_bad_request(
+def test_set_backup_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetBackupTargetPoolRequest
 ):
     client = TargetPoolsClient(
@@ -2153,14 +2153,14 @@ def test_set_backup_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_backup(request)
+        client.set_backup_unary(request)
 
 
-def test_set_backup_rest_from_dict():
-    test_set_backup_rest(request_type=dict)
+def test_set_backup_unary_rest_from_dict():
+    test_set_backup_unary_rest(request_type=dict)
 
 
-def test_set_backup_rest_flattened(transport: str = "rest"):
+def test_set_backup_unary_rest_flattened(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2193,7 +2193,7 @@ def test_set_backup_rest_flattened(transport: str = "rest"):
             target_reference_resource=compute.TargetReference(target="target_value"),
         )
         mock_args.update(sample_request)
-        client.set_backup(**mock_args)
+        client.set_backup_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -2206,7 +2206,7 @@ def test_set_backup_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_backup_rest_flattened_error(transport: str = "rest"):
+def test_set_backup_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetPoolsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -2214,7 +2214,7 @@ def test_set_backup_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_backup(
+        client.set_backup_unary(
             compute.SetBackupTargetPoolRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_target_ssl_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_target_ssl_proxies.py
@@ -420,7 +420,7 @@ def test_target_ssl_proxies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -465,7 +465,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -493,7 +493,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -513,14 +513,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -546,7 +546,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", target_ssl_proxy="target_ssl_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -559,7 +559,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -567,7 +567,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy="target_ssl_proxy_value",
@@ -704,7 +704,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -752,7 +752,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -780,7 +780,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -803,14 +803,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -839,7 +839,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -852,7 +852,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -860,7 +860,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy_resource=compute.TargetSslProxy(
@@ -1032,7 +1032,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_backend_service_rest(
+def test_set_backend_service_unary_rest(
     transport: str = "rest", request_type=compute.SetBackendServiceTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1080,7 +1080,7 @@ def test_set_backend_service_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_backend_service(request)
+        response = client.set_backend_service_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1108,7 +1108,7 @@ def test_set_backend_service_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_backend_service_rest_bad_request(
+def test_set_backend_service_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetBackendServiceTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1131,14 +1131,14 @@ def test_set_backend_service_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_backend_service(request)
+        client.set_backend_service_unary(request)
 
 
-def test_set_backend_service_rest_from_dict():
-    test_set_backend_service_rest(request_type=dict)
+def test_set_backend_service_unary_rest_from_dict():
+    test_set_backend_service_unary_rest(request_type=dict)
 
 
-def test_set_backend_service_rest_flattened(transport: str = "rest"):
+def test_set_backend_service_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1168,7 +1168,7 @@ def test_set_backend_service_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_backend_service(**mock_args)
+        client.set_backend_service_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1181,7 +1181,7 @@ def test_set_backend_service_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
+def test_set_backend_service_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1189,7 +1189,7 @@ def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_backend_service(
+        client.set_backend_service_unary(
             compute.SetBackendServiceTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy="target_ssl_proxy_value",
@@ -1199,7 +1199,7 @@ def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_proxy_header_rest(
+def test_set_proxy_header_unary_rest(
     transport: str = "rest", request_type=compute.SetProxyHeaderTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1247,7 +1247,7 @@ def test_set_proxy_header_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_proxy_header(request)
+        response = client.set_proxy_header_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1275,7 +1275,7 @@ def test_set_proxy_header_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_proxy_header_rest_bad_request(
+def test_set_proxy_header_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetProxyHeaderTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1298,14 +1298,14 @@ def test_set_proxy_header_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_proxy_header(request)
+        client.set_proxy_header_unary(request)
 
 
-def test_set_proxy_header_rest_from_dict():
-    test_set_proxy_header_rest(request_type=dict)
+def test_set_proxy_header_unary_rest_from_dict():
+    test_set_proxy_header_unary_rest(request_type=dict)
 
 
-def test_set_proxy_header_rest_flattened(transport: str = "rest"):
+def test_set_proxy_header_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1335,7 +1335,7 @@ def test_set_proxy_header_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_proxy_header(**mock_args)
+        client.set_proxy_header_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1348,7 +1348,7 @@ def test_set_proxy_header_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_proxy_header_rest_flattened_error(transport: str = "rest"):
+def test_set_proxy_header_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1356,7 +1356,7 @@ def test_set_proxy_header_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_proxy_header(
+        client.set_proxy_header_unary(
             compute.SetProxyHeaderTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy="target_ssl_proxy_value",
@@ -1366,7 +1366,7 @@ def test_set_proxy_header_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_ssl_certificates_rest(
+def test_set_ssl_certificates_unary_rest(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesTargetSslProxyRequest,
 ):
@@ -1417,7 +1417,7 @@ def test_set_ssl_certificates_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_ssl_certificates(request)
+        response = client.set_ssl_certificates_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1445,7 +1445,7 @@ def test_set_ssl_certificates_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_ssl_certificates_rest_bad_request(
+def test_set_ssl_certificates_unary_rest_bad_request(
     transport: str = "rest",
     request_type=compute.SetSslCertificatesTargetSslProxyRequest,
 ):
@@ -1471,14 +1471,14 @@ def test_set_ssl_certificates_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_ssl_certificates(request)
+        client.set_ssl_certificates_unary(request)
 
 
-def test_set_ssl_certificates_rest_from_dict():
-    test_set_ssl_certificates_rest(request_type=dict)
+def test_set_ssl_certificates_unary_rest_from_dict():
+    test_set_ssl_certificates_unary_rest(request_type=dict)
 
 
-def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1508,7 +1508,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_ssl_certificates(**mock_args)
+        client.set_ssl_certificates_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1521,7 +1521,7 @@ def test_set_ssl_certificates_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
+def test_set_ssl_certificates_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1529,7 +1529,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_ssl_certificates(
+        client.set_ssl_certificates_unary(
             compute.SetSslCertificatesTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy="target_ssl_proxy_value",
@@ -1539,7 +1539,7 @@ def test_set_ssl_certificates_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_ssl_policy_rest(
+def test_set_ssl_policy_unary_rest(
     transport: str = "rest", request_type=compute.SetSslPolicyTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1587,7 +1587,7 @@ def test_set_ssl_policy_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_ssl_policy(request)
+        response = client.set_ssl_policy_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1615,7 +1615,7 @@ def test_set_ssl_policy_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_ssl_policy_rest_bad_request(
+def test_set_ssl_policy_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetSslPolicyTargetSslProxyRequest
 ):
     client = TargetSslProxiesClient(
@@ -1638,14 +1638,14 @@ def test_set_ssl_policy_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_ssl_policy(request)
+        client.set_ssl_policy_unary(request)
 
 
-def test_set_ssl_policy_rest_from_dict():
-    test_set_ssl_policy_rest(request_type=dict)
+def test_set_ssl_policy_unary_rest_from_dict():
+    test_set_ssl_policy_unary_rest(request_type=dict)
 
 
-def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
+def test_set_ssl_policy_unary_rest_flattened(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1675,7 +1675,7 @@ def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_ssl_policy(**mock_args)
+        client.set_ssl_policy_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1688,7 +1688,7 @@ def test_set_ssl_policy_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_ssl_policy_rest_flattened_error(transport: str = "rest"):
+def test_set_ssl_policy_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetSslProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1696,7 +1696,7 @@ def test_set_ssl_policy_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_ssl_policy(
+        client.set_ssl_policy_unary(
             compute.SetSslPolicyTargetSslProxyRequest(),
             project="project_value",
             target_ssl_proxy="target_ssl_proxy_value",

--- a/tests/unit/gapic/compute_v1/test_target_tcp_proxies.py
+++ b/tests/unit/gapic/compute_v1/test_target_tcp_proxies.py
@@ -420,7 +420,7 @@ def test_target_tcp_proxies_client_client_options_credentials_file(
         )
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -465,7 +465,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -493,7 +493,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -513,14 +513,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -546,7 +546,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             project="project_value", target_tcp_proxy="target_tcp_proxy_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -559,7 +559,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -567,7 +567,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetTcpProxyRequest(),
             project="project_value",
             target_tcp_proxy="target_tcp_proxy_value",
@@ -702,7 +702,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -750,7 +750,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -778,7 +778,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -801,14 +801,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -837,7 +837,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -850,7 +850,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -858,7 +858,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetTcpProxyRequest(),
             project="project_value",
             target_tcp_proxy_resource=compute.TargetTcpProxy(
@@ -1030,7 +1030,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_backend_service_rest(
+def test_set_backend_service_unary_rest(
     transport: str = "rest", request_type=compute.SetBackendServiceTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -1078,7 +1078,7 @@ def test_set_backend_service_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_backend_service(request)
+        response = client.set_backend_service_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1106,7 +1106,7 @@ def test_set_backend_service_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_backend_service_rest_bad_request(
+def test_set_backend_service_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetBackendServiceTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -1129,14 +1129,14 @@ def test_set_backend_service_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_backend_service(request)
+        client.set_backend_service_unary(request)
 
 
-def test_set_backend_service_rest_from_dict():
-    test_set_backend_service_rest(request_type=dict)
+def test_set_backend_service_unary_rest_from_dict():
+    test_set_backend_service_unary_rest(request_type=dict)
 
 
-def test_set_backend_service_rest_flattened(transport: str = "rest"):
+def test_set_backend_service_unary_rest_flattened(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1166,7 +1166,7 @@ def test_set_backend_service_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_backend_service(**mock_args)
+        client.set_backend_service_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1179,7 +1179,7 @@ def test_set_backend_service_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
+def test_set_backend_service_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1187,7 +1187,7 @@ def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_backend_service(
+        client.set_backend_service_unary(
             compute.SetBackendServiceTargetTcpProxyRequest(),
             project="project_value",
             target_tcp_proxy="target_tcp_proxy_value",
@@ -1197,7 +1197,7 @@ def test_set_backend_service_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_set_proxy_header_rest(
+def test_set_proxy_header_unary_rest(
     transport: str = "rest", request_type=compute.SetProxyHeaderTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -1245,7 +1245,7 @@ def test_set_proxy_header_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_proxy_header(request)
+        response = client.set_proxy_header_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1273,7 +1273,7 @@ def test_set_proxy_header_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_proxy_header_rest_bad_request(
+def test_set_proxy_header_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetProxyHeaderTargetTcpProxyRequest
 ):
     client = TargetTcpProxiesClient(
@@ -1296,14 +1296,14 @@ def test_set_proxy_header_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_proxy_header(request)
+        client.set_proxy_header_unary(request)
 
 
-def test_set_proxy_header_rest_from_dict():
-    test_set_proxy_header_rest(request_type=dict)
+def test_set_proxy_header_unary_rest_from_dict():
+    test_set_proxy_header_unary_rest(request_type=dict)
 
 
-def test_set_proxy_header_rest_flattened(transport: str = "rest"):
+def test_set_proxy_header_unary_rest_flattened(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1333,7 +1333,7 @@ def test_set_proxy_header_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_proxy_header(**mock_args)
+        client.set_proxy_header_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1346,7 +1346,7 @@ def test_set_proxy_header_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_proxy_header_rest_flattened_error(transport: str = "rest"):
+def test_set_proxy_header_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetTcpProxiesClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1354,7 +1354,7 @@ def test_set_proxy_header_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_proxy_header(
+        client.set_proxy_header_unary(
             compute.SetProxyHeaderTargetTcpProxyRequest(),
             project="project_value",
             target_tcp_proxy="target_tcp_proxy_value",

--- a/tests/unit/gapic/compute_v1/test_target_vpn_gateways.py
+++ b/tests/unit/gapic/compute_v1/test_target_vpn_gateways.py
@@ -603,7 +603,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteTargetVpnGatewayRequest
 ):
     client = TargetVpnGatewaysClient(
@@ -652,7 +652,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -680,7 +680,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteTargetVpnGatewayRequest
 ):
     client = TargetVpnGatewaysClient(
@@ -704,14 +704,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = TargetVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -743,7 +743,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             target_vpn_gateway="target_vpn_gateway_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -756,7 +756,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -764,7 +764,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteTargetVpnGatewayRequest(),
             project="project_value",
             region="region_value",
@@ -919,7 +919,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertTargetVpnGatewayRequest
 ):
     client = TargetVpnGatewaysClient(
@@ -967,7 +967,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -995,7 +995,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertTargetVpnGatewayRequest
 ):
     client = TargetVpnGatewaysClient(
@@ -1018,14 +1018,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = TargetVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1055,7 +1055,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1068,7 +1068,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = TargetVpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1076,7 +1076,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertTargetVpnGatewayRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_url_maps.py
+++ b/tests/unit/gapic/compute_v1/test_url_maps.py
@@ -573,7 +573,9 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(transport: str = "rest", request_type=compute.DeleteUrlMapRequest):
+def test_delete_unary_rest(
+    transport: str = "rest", request_type=compute.DeleteUrlMapRequest
+):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -616,7 +618,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteUrlMapR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -644,7 +646,7 @@ def test_delete_rest(transport: str = "rest", request_type=compute.DeleteUrlMapR
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -664,14 +666,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -695,7 +697,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         # get truthy value for each flattened field
         mock_args = dict(project="project_value", url_map="url_map_value",)
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -708,7 +710,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -716,7 +718,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteUrlMapRequest(),
             project="project_value",
             url_map="url_map_value",
@@ -847,7 +849,9 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(transport: str = "rest", request_type=compute.InsertUrlMapRequest):
+def test_insert_unary_rest(
+    transport: str = "rest", request_type=compute.InsertUrlMapRequest
+):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -893,7 +897,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertUrlMapR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -921,7 +925,7 @@ def test_insert_rest(transport: str = "rest", request_type=compute.InsertUrlMapR
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -944,14 +948,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -980,7 +984,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -993,7 +997,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1001,7 +1005,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertUrlMapRequest(),
             project="project_value",
             url_map_resource=compute.UrlMap(
@@ -1010,7 +1014,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_invalidate_cache_rest(
+def test_invalidate_cache_unary_rest(
     transport: str = "rest", request_type=compute.InvalidateCacheUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -1058,7 +1062,7 @@ def test_invalidate_cache_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.invalidate_cache(request)
+        response = client.invalidate_cache_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1086,7 +1090,7 @@ def test_invalidate_cache_rest(
     assert response.zone == "zone_value"
 
 
-def test_invalidate_cache_rest_bad_request(
+def test_invalidate_cache_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InvalidateCacheUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -1109,14 +1113,14 @@ def test_invalidate_cache_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.invalidate_cache(request)
+        client.invalidate_cache_unary(request)
 
 
-def test_invalidate_cache_rest_from_dict():
-    test_invalidate_cache_rest(request_type=dict)
+def test_invalidate_cache_unary_rest_from_dict():
+    test_invalidate_cache_unary_rest(request_type=dict)
 
 
-def test_invalidate_cache_rest_flattened(transport: str = "rest"):
+def test_invalidate_cache_unary_rest_flattened(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1146,7 +1150,7 @@ def test_invalidate_cache_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.invalidate_cache(**mock_args)
+        client.invalidate_cache_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1159,7 +1163,7 @@ def test_invalidate_cache_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_invalidate_cache_rest_flattened_error(transport: str = "rest"):
+def test_invalidate_cache_unary_rest_flattened_error(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1167,7 +1171,7 @@ def test_invalidate_cache_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.invalidate_cache(
+        client.invalidate_cache_unary(
             compute.InvalidateCacheUrlMapRequest(),
             project="project_value",
             url_map="url_map_value",
@@ -1330,7 +1334,9 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_patch_rest(transport: str = "rest", request_type=compute.PatchUrlMapRequest):
+def test_patch_unary_rest(
+    transport: str = "rest", request_type=compute.PatchUrlMapRequest
+):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1376,7 +1382,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchUrlMapReq
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.patch(request)
+        response = client.patch_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1404,7 +1410,7 @@ def test_patch_rest(transport: str = "rest", request_type=compute.PatchUrlMapReq
     assert response.zone == "zone_value"
 
 
-def test_patch_rest_bad_request(
+def test_patch_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.PatchUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -1427,14 +1433,14 @@ def test_patch_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.patch(request)
+        client.patch_unary(request)
 
 
-def test_patch_rest_from_dict():
-    test_patch_rest(request_type=dict)
+def test_patch_unary_rest_from_dict():
+    test_patch_unary_rest(request_type=dict)
 
 
-def test_patch_rest_flattened(transport: str = "rest"):
+def test_patch_unary_rest_flattened(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1464,7 +1470,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.patch(**mock_args)
+        client.patch_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1477,7 +1483,7 @@ def test_patch_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_patch_rest_flattened_error(transport: str = "rest"):
+def test_patch_unary_rest_flattened_error(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1485,7 +1491,7 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.patch(
+        client.patch_unary(
             compute.PatchUrlMapRequest(),
             project="project_value",
             url_map="url_map_value",
@@ -1495,7 +1501,9 @@ def test_patch_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_update_rest(transport: str = "rest", request_type=compute.UpdateUrlMapRequest):
+def test_update_unary_rest(
+    transport: str = "rest", request_type=compute.UpdateUrlMapRequest
+):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1541,7 +1549,7 @@ def test_update_rest(transport: str = "rest", request_type=compute.UpdateUrlMapR
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.update(request)
+        response = client.update_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1569,7 +1577,7 @@ def test_update_rest(transport: str = "rest", request_type=compute.UpdateUrlMapR
     assert response.zone == "zone_value"
 
 
-def test_update_rest_bad_request(
+def test_update_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.UpdateUrlMapRequest
 ):
     client = UrlMapsClient(
@@ -1592,14 +1600,14 @@ def test_update_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.update(request)
+        client.update_unary(request)
 
 
-def test_update_rest_from_dict():
-    test_update_rest(request_type=dict)
+def test_update_unary_rest_from_dict():
+    test_update_unary_rest(request_type=dict)
 
 
-def test_update_rest_flattened(transport: str = "rest"):
+def test_update_unary_rest_flattened(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1629,7 +1637,7 @@ def test_update_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.update(**mock_args)
+        client.update_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1642,7 +1650,7 @@ def test_update_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_update_rest_flattened_error(transport: str = "rest"):
+def test_update_unary_rest_flattened_error(transport: str = "rest"):
     client = UrlMapsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1650,7 +1658,7 @@ def test_update_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.update(
+        client.update_unary(
             compute.UpdateUrlMapRequest(),
             project="project_value",
             url_map="url_map_value",

--- a/tests/unit/gapic/compute_v1/test_vpn_gateways.py
+++ b/tests/unit/gapic/compute_v1/test_vpn_gateways.py
@@ -581,7 +581,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -626,7 +626,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -654,7 +654,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -674,14 +674,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -713,7 +713,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             vpn_gateway="vpn_gateway_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -726,7 +726,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -734,7 +734,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteVpnGatewayRequest(),
             project="project_value",
             region="region_value",
@@ -991,7 +991,7 @@ def test_get_status_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -1039,7 +1039,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1067,7 +1067,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -1090,14 +1090,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1127,7 +1127,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1140,7 +1140,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1148,7 +1148,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertVpnGatewayRequest(),
             project="project_value",
             region="region_value",
@@ -1323,7 +1323,7 @@ def test_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_set_labels_rest(
+def test_set_labels_unary_rest(
     transport: str = "rest", request_type=compute.SetLabelsVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -1371,7 +1371,7 @@ def test_set_labels_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.set_labels(request)
+        response = client.set_labels_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -1399,7 +1399,7 @@ def test_set_labels_rest(
     assert response.zone == "zone_value"
 
 
-def test_set_labels_rest_bad_request(
+def test_set_labels_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.SetLabelsVpnGatewayRequest
 ):
     client = VpnGatewaysClient(
@@ -1422,14 +1422,14 @@ def test_set_labels_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.set_labels(request)
+        client.set_labels_unary(request)
 
 
-def test_set_labels_rest_from_dict():
-    test_set_labels_rest(request_type=dict)
+def test_set_labels_unary_rest_from_dict():
+    test_set_labels_unary_rest(request_type=dict)
 
 
-def test_set_labels_rest_flattened(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1464,7 +1464,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.set_labels(**mock_args)
+        client.set_labels_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1477,7 +1477,7 @@ def test_set_labels_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_set_labels_rest_flattened_error(transport: str = "rest"):
+def test_set_labels_unary_rest_flattened_error(transport: str = "rest"):
     client = VpnGatewaysClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1485,7 +1485,7 @@ def test_set_labels_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.set_labels(
+        client.set_labels_unary(
             compute.SetLabelsVpnGatewayRequest(),
             project="project_value",
             region="region_value",

--- a/tests/unit/gapic/compute_v1/test_vpn_tunnels.py
+++ b/tests/unit/gapic/compute_v1/test_vpn_tunnels.py
@@ -578,7 +578,7 @@ def test_aggregated_list_rest_pager():
             assert page_.raw_page.next_page_token == token
 
 
-def test_delete_rest(
+def test_delete_unary_rest(
     transport: str = "rest", request_type=compute.DeleteVpnTunnelRequest
 ):
     client = VpnTunnelsClient(
@@ -623,7 +623,7 @@ def test_delete_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.delete(request)
+        response = client.delete_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -651,7 +651,7 @@ def test_delete_rest(
     assert response.zone == "zone_value"
 
 
-def test_delete_rest_bad_request(
+def test_delete_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.DeleteVpnTunnelRequest
 ):
     client = VpnTunnelsClient(
@@ -671,14 +671,14 @@ def test_delete_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.delete(request)
+        client.delete_unary(request)
 
 
-def test_delete_rest_from_dict():
-    test_delete_rest(request_type=dict)
+def test_delete_unary_rest_from_dict():
+    test_delete_unary_rest(request_type=dict)
 
 
-def test_delete_rest_flattened(transport: str = "rest"):
+def test_delete_unary_rest_flattened(transport: str = "rest"):
     client = VpnTunnelsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -710,7 +710,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
             vpn_tunnel="vpn_tunnel_value",
         )
         mock_args.update(sample_request)
-        client.delete(**mock_args)
+        client.delete_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -723,7 +723,7 @@ def test_delete_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_delete_rest_flattened_error(transport: str = "rest"):
+def test_delete_unary_rest_flattened_error(transport: str = "rest"):
     client = VpnTunnelsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -731,7 +731,7 @@ def test_delete_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.delete(
+        client.delete_unary(
             compute.DeleteVpnTunnelRequest(),
             project="project_value",
             region="region_value",
@@ -898,7 +898,7 @@ def test_get_rest_flattened_error(transport: str = "rest"):
         )
 
 
-def test_insert_rest(
+def test_insert_unary_rest(
     transport: str = "rest", request_type=compute.InsertVpnTunnelRequest
 ):
     client = VpnTunnelsClient(
@@ -946,7 +946,7 @@ def test_insert_rest(
         json_return_value = compute.Operation.to_json(return_value)
         response_value._content = json_return_value.encode("UTF-8")
         req.return_value = response_value
-        response = client.insert(request)
+        response = client.insert_unary(request)
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, compute.Operation)
@@ -974,7 +974,7 @@ def test_insert_rest(
     assert response.zone == "zone_value"
 
 
-def test_insert_rest_bad_request(
+def test_insert_unary_rest_bad_request(
     transport: str = "rest", request_type=compute.InsertVpnTunnelRequest
 ):
     client = VpnTunnelsClient(
@@ -997,14 +997,14 @@ def test_insert_rest_bad_request(
         response_value.status_code = 400
         response_value.request = Request()
         req.return_value = response_value
-        client.insert(request)
+        client.insert_unary(request)
 
 
-def test_insert_rest_from_dict():
-    test_insert_rest(request_type=dict)
+def test_insert_unary_rest_from_dict():
+    test_insert_unary_rest(request_type=dict)
 
 
-def test_insert_rest_flattened(transport: str = "rest"):
+def test_insert_unary_rest_flattened(transport: str = "rest"):
     client = VpnTunnelsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1034,7 +1034,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
             ),
         )
         mock_args.update(sample_request)
-        client.insert(**mock_args)
+        client.insert_unary(**mock_args)
 
         # Establish that the underlying call was made with the expected
         # request object values.
@@ -1047,7 +1047,7 @@ def test_insert_rest_flattened(transport: str = "rest"):
         )
 
 
-def test_insert_rest_flattened_error(transport: str = "rest"):
+def test_insert_unary_rest_flattened_error(transport: str = "rest"):
     client = VpnTunnelsClient(
         credentials=ga_credentials.AnonymousCredentials(), transport=transport,
     )
@@ -1055,7 +1055,7 @@ def test_insert_rest_flattened_error(transport: str = "rest"):
     # Attempting to call a method with both a request object and flattened
     # fields is an error.
     with pytest.raises(ValueError):
-        client.insert(
+        client.insert_unary(
             compute.InsertVpnTunnelRequest(),
             project="project_value",
             region="region_value",


### PR DESCRIPTION
Update `python-compute` with a newer version of the generator at [this](https://github.com/googleapis/gapic-generator-python/tree/956078f7e6ea502ae9f7330bcc7aea803b177508) commit.