### PR TITLE
chore(samples): Fixing a small issue with sample region tags

### DIFF
--- a/samples/snippets/sample_create_vm.py
+++ b/samples/snippets/sample_create_vm.py
@@ -20,11 +20,11 @@ from typing import List
 # [START compute_instances_create_from_snapshot]
 # [START compute_instances_create_from_image_plus_empty_disk]
 # [START compute_instances_create_from_custom_image]
-# [START compute_instances_create_from_image ]
+# [START compute_instances_create_from_image]
 from google.cloud import compute_v1
 
 
-# [END compute_instances_create_from_image ]
+# [END compute_instances_create_from_image]
 # [END compute_instances_create_from_custom_image]
 # [END compute_instances_create_from_image_plus_empty_disk]
 # [END compute_instances_create_from_snapshot]


### PR DESCRIPTION
Fixing a small problem with the region tags - this trailing whitespace made the tags appear in the code when the file was imported to our documentation pages.
