### PR TITLE
chore(samples): Fixing test with deprecated OS image.

### DIFF
--- a/samples/snippets/test_sample_instance_from_template.py
+++ b/samples/snippets/test_sample_instance_from_template.py
@@ -85,7 +85,9 @@ def test_create_instance_from_template_override(
 ):
     image_client = compute_v1.ImagesClient()
 
-    image = image_client.get_from_family(project="ubuntu-os-cloud", family="ubuntu-2004-lts")
+    image = image_client.get_from_family(
+        project="ubuntu-os-cloud", family="ubuntu-2004-lts"
+    )
     instance = create_instance_from_template_with_overrides(
         PROJECT,
         INSTANCE_ZONE,

--- a/samples/snippets/test_sample_instance_from_template.py
+++ b/samples/snippets/test_sample_instance_from_template.py
@@ -85,7 +85,7 @@ def test_create_instance_from_template_override(
 ):
     image_client = compute_v1.ImagesClient()
 
-    image = image_client.get_from_family(project="centos-cloud", family="centos-8")
+    image = image_client.get_from_family(project="ubuntu-os-cloud", family="ubuntu-2004-lts")
     instance = create_instance_from_template_with_overrides(
         PROJECT,
         INSTANCE_ZONE,


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)


This PR fixes a test that started failing because CentOS 8 was deprecated, so it is no longer available as a public OS image. It's now replaced with Ubuntu LTS.
