### PR TITLE
chore(readme): Updating readme with PyCharm code completion info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,15 @@ Windows
     <your-env>\Scripts\activate
     <your-env>\Scripts\pip.exe install google-cloud-compute
 
+
+PyCharm/JetBrains IDEs
+~~~~~~~~~~~~~~~~~~~~~~
+Since the library has grown in size, the files it consists of have outgrown the [default size limit of ~2.5Mb](https://www.jetbrains.com/help/pycharm/file-idea-properties.html).
+As a result, the code completion in JetBrains products can fail to work with the classes from our library. To
+fix this, you need to update the `idea.max.intellisense.filesize` setting in custom properties
+(Help -> Edit custom properties...). Just add a line like `idea.max.intellisense.filesize = 10000` to change this
+limit to ~10Mb.
+
 Next Steps
 ~~~~~~~~~~
 


### PR DESCRIPTION
Code completion stopped working in PyCharm since the library files grew over 2.5Mb. Code completion is extremely important for usability of a library.

Part of solution for issue #245 
