### PR TITLE
docs(samples): Adding a missing region tag

### DIFF
--- a/samples/ingredients/instances/create_start_instance/create_windows_instance.py
+++ b/samples/ingredients/instances/create_start_instance/create_windows_instance.py
@@ -67,9 +67,15 @@ def create_windows_instance(project_id: str, zone: str, instance_name: str,
     # that contain Windows instances with only internal IP addresses.
     # More information about Private Google Access: https://cloud.google.com/vpc/docs/configure-private-google-access#enabling
 
-    instance = create_instance(project_id, zone, instance_name, disks,
-                               machine_type=machine_type, network_link=network_link,
-                               subnetwork_link=subnetwork_link, external_access=True,
-                               )
+    instance = create_instance(
+        project_id,
+        zone,
+        instance_name,
+        disks,
+        machine_type=machine_type,
+        network_link=network_link,
+        subnetwork_link=subnetwork_link,
+        external_access=True,  # Set this to False to disable external IP for your instance
+    )
     return instance
 # </INGREDIENT>

--- a/samples/recipes/instances/create_start_instance/create_windows_instance.py
+++ b/samples/recipes/instances/create_start_instance/create_windows_instance.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 # flake8: noqa
 
+# <REGION compute_create_windows_instance_external_ip>
 # <REGION compute_create_windows_instance_internal_ip>
 # <IMPORTS/>
 
@@ -29,3 +30,4 @@
 
 # <INGREDIENT create_windows_instance />
 # </REGION compute_create_windows_instance_internal_ip>
+# </REGION compute_create_windows_instance_external_ip>

--- a/samples/snippets/instances/create_start_instance/create_windows_instance.py
+++ b/samples/snippets/instances/create_start_instance/create_windows_instance.py
@@ -19,6 +19,7 @@
 # directory and apply your changes there.
 
 
+# [START compute_create_windows_instance_external_ip]
 # [START compute_create_windows_instance_internal_ip]
 import re
 import sys
@@ -305,9 +306,10 @@ def create_windows_instance(
         machine_type=machine_type,
         network_link=network_link,
         subnetwork_link=subnetwork_link,
-        external_access=True,
+        external_access=True,  # Set this to False to disable external IP for your instance
     )
     return instance
 
 
 # [END compute_create_windows_instance_internal_ip]
+# [END compute_create_windows_instance_external_ip]


### PR DESCRIPTION
Turns out I missed the `compute_create_windows_instance_external_ip` region tag when I first made those samples. Adding it now.
